### PR TITLE
add link to po translation instructions in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Installation of development environment
 Translations
 ------------
 Axolotl uses gettext for translations. Use the po files in `/po/` for translations.
-For testing set up  development enviroment and run
+Instructions on how to translate using `.po` files are available here: http://docs.ubports.com/en/latest/contribute/translations.html#po-ts-file-editor
+
+Once you finished translating, test the strings. For testing set up  development enviroment as above and run
 * `npm run translate-extract` extracting the language strings. This updates only the pot file
 * `npm run translate-update` for updating all the translation files
 * `npm run translate-compile` for updating the json file used by axolotl-web. Without that you don't see any results

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Installation of development environment
 
 Translations
 ------------
-Axolotl uses gettext for translations. Use the po files in `/po/` for translations.
+Axolotl uses gettext for translations. Use the `.po` files in `/po/` for translations.
 Instructions on how to translate using `.po` files are available here: http://docs.ubports.com/en/latest/contribute/translations.html#po-ts-file-editor
 
 Once you finished translating, test the strings. For testing set up  development enviroment as above and run


### PR DESCRIPTION
I think it does not hurt to provide some more information on how to translate a po file. Because the instructions are there, maybe adding a link is a good thing to do.