### PR TITLE
Make webserver address configurable and bind only to that host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Run development
 * `cd $(go env GOPATH)/src/github.com/nanu-c/axolotl`
 * `go run .`
 * in a new terminal `cd axolotl-web&&npm run serve`
-* point a browser to the link printed in the terminal  like `http://localhost:8080`
+* point a browser to the link printed in the terminal  like `http://localhost:9080`
 
 Run frontend and connect to phone ip
 --------------
@@ -139,8 +139,10 @@ The build-system is now integrated in the `clickable` Version 3.2.0.
 Run flags
 -----------
 
-* `-sys` for either `lorca`-> native chromium (has to be installed), `ut` -> runs in the ut enviroment, `me` -> qmlscene, or without that flag it runs electron
+* `-sys` for either `lorca`-> native chromium (has to be installed), `ut` -> runs in the ut enviroment, `me` -> qmlscene, `server` -> just run the webserver, or without that flag it runs electron
 * `-eDebug` show developer console in electron mode
+* `-host` Set the host to run the webserver from. Defaults to localhost.
+* `-port` Set the port to run the webserver from. Defaults to 9080.
 
 Contributing
 -----------

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -41,6 +41,8 @@ var (
 	AttachDir              string
 	TsDeviceURL            string
 	VcardPath              string
+	ServerHost             string
+	ServerPort             string
 )
 
 var Config *textsecure.Config

--- a/app/ui/gui.go
+++ b/app/ui/gui.go
@@ -85,7 +85,7 @@ func RunUi(e string) {
 		ui.Bind("start", func() {
 			log.Println("[axolotl] UI is ready")
 		})
-		ui.Load(fmt.Sprintf("http://localhost:9080"))
+		ui.Load(fmt.Sprintf("http://%s:%s", config.ServerHost, config.ServerPort))
 
 		// Wait until the interrupt signal arrives or browser window is closed
 		sigc := make(chan os.Signal)

--- a/app/webserver/webserver.go
+++ b/app/webserver/webserver.go
@@ -386,7 +386,7 @@ func webserver() {
 		http.HandleFunc("/attachments", attachmentsHandler)
 		http.HandleFunc("/avatars", avatarsHandler)
 		http.HandleFunc("/ws", wsEndpoint)
-		log.Error("[axoltol] webserver error", http.ListenAndServe(":9080", nil))
+		log.Error("[axoltol] webserver error", http.ListenAndServe(config.ServerHost + ":" + config.ServerPort, nil))
 	}
 
 }

--- a/axolotl-web/src/main.js
+++ b/axolotl-web/src/main.js
@@ -35,7 +35,13 @@ Vue.use(BootstrapVue)
 Vue.use(GetTextPlugin, {translations: translations, defaultLanguage: 'en',})
 Vue.directive('linkified', linkify)
 Vue.config.productionTip = false
-var websocketAdress = "ws://[::1]:9080/ws";
+var websocketAdress = "ws://";
+if (window.location.protocol === "https:") {
+  websocketAdress = "wss://";
+}
+websocketAdress += window.location.host;
+websocketAdress += "/ws";
+
 if(process.env.NODE_ENV=="development"){
   if(process.env.VUE_APP_WS_ADDRESS){
     websocketAdress =  'ws://'+process.env.VUE_APP_WS_ADDRESS+':9080/ws';

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func init() {
 	flag.StringVar(&config.MainQml, "qml", "qml/phoneui/main.qml", "The qml file to load.")
 	flag.StringVar(&config.Gui, "e", "", "use either electron, ut, lorca, server or me")
 	flag.BoolVar(&config.ElectronDebug, "eDebug", false, "use to show development console in electron")
+	flag.StringVar(&config.ServerHost, "host", "localhost", "Host to serve UI from.")
+	flag.StringVar(&config.ServerPort, "port", "9080", "Port to serve UI from.")
 }
 func print(stdout io.ReadCloser) {
 	scanner := bufio.NewScanner(stdout)
@@ -99,7 +101,7 @@ func runElectron() {
 	center := true
 	height := 800
 	width := 600
-	if w, err = a.NewWindow("http://localhost:9080", &astilectron.WindowOptions{
+	if w, err = a.NewWindow("http://" + config.ServerHost + ":" + config.ServerPort, &astilectron.WindowOptions{
 		Center: &center,
 		Height: &height,
 		Width:  &width,
@@ -140,7 +142,7 @@ func main() {
 		wg.Add(1)
 		go runUI()
 	} else {
-		log.Printf("[axolotl] Axolotl frontend is at http://localhost:9080/")
+		log.Printf("[axolotl] Axolotl frontend is at http://" + config.ServerHost + ":" + config.ServerPort + "/")
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
The webserver is by default accessible by everyone over the network. This PR restricts that to localhost, but also adds the flags `-host` and `-port` to make that configurable.

See also #64.