### PR TITLE
Only push to dbus if available

### DIFF
--- a/app/webserver/webserver.go
+++ b/app/webserver/webserver.go
@@ -115,7 +115,9 @@ func wsReader(conn *websocket.Conn) {
 			id := getMessageListMessage.ID
 			activeChat = getMessageListMessage.ID
 			store.ActiveSessionID = activeChat
-			push.Nh.Clear(id)
+			if push.Nh != nil {
+				push.Nh.Clear(id)
+			}
 			log.Debugln("[axolotl] Enter chat ", id)
 			sendMessageList(id)
 		case "setDarkMode":


### PR DESCRIPTION
In a server-only environment dbus is not available, leading to a panic.