### PR TITLE
Show fingerprint (safety numbers) instead of hex codes

### DIFF
--- a/app/webserver/helpers.go
+++ b/app/webserver/helpers.go
@@ -236,13 +236,12 @@ func sendMoreMessageList(id string, lastId string) {
 	// defer mu.Unlock()
 	broadcast <- *message
 }
-func sendIdentityInfo(myId []byte, theirId []byte) {
+func sendIdentityInfo(fingerprint []string) {
 	var err error
 
 	message := &[]byte{}
 	identityEnvelope := &IdentityEnvelope{
-		Identity: fmt.Sprintf("% 0X", myId),
-		TheirId:  fmt.Sprintf("% 0X", theirId),
+		Fingerprint: fingerprint,
 	}
 	*message, err = json.Marshal(identityEnvelope)
 	if err != nil {

--- a/app/webserver/messages.go
+++ b/app/webserver/messages.go
@@ -37,8 +37,7 @@ type UpdateCurrentChatEnvelope struct {
 	UpdateCurrentChat *UpdateCurrentChat
 }
 type IdentityEnvelope struct {
-	Identity string
-	TheirId  string
+	Fingerprint []string
 }
 type ConfigEnvelope struct {
 	Type             string

--- a/app/webserver/webserver.go
+++ b/app/webserver/webserver.go
@@ -361,13 +361,11 @@ func wsReader(conn *websocket.Conn) {
 			verifyIdentityMessage := ToggleNotificationsMessage{}
 			json.Unmarshal([]byte(p), &verifyIdentityMessage)
 			log.Debugln("[axolotl] identity information for: ", verifyIdentityMessage.Chat)
-			myID := textsecure.MyIdentityKey()
-			theirID, err := textsecure.ContactIdentityKey(verifyIdentityMessage.Chat)
-			log.Debugln(myID, theirID)
+			fingerprint, err := textsecure.GetFingerprint(verifyIdentityMessage.Chat)
 			if err != nil {
 				log.Debugln("[axolotl] identity information ", err)
 			}
-			sendIdentityInfo(myID, theirID)
+			sendIdentityInfo(fingerprint)
 		}
 	}
 }

--- a/axolotl-web/src/components/IdentityModal.vue
+++ b/axolotl-web/src/components/IdentityModal.vue
@@ -9,14 +9,12 @@
           </button>
         </div>
         <div class="modal-body">
-          <b v-translate>Your key </b>
-          <br />
-          <div >{{identity.me}}</div>
-          <br />
-          <br />
-          <b>{{currentChat.Name}}<span v-translate>'s key </span></b>
-          <br />
-          <div >{{identity.their}}</div>
+          <b><span v-translate>Safety numbers of you and</span> {{currentChat.Name}}:</b>
+          <div class="row fingerprint">
+            <div class="col-3" v-for="(part,i) in fingerprint" v-bind:key="'fingerprint_'+i">
+                {{ part }}
+            </div>
+          </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" @click="$emit('confirm')" v-translate>Close</button>
           </div>
@@ -32,8 +30,8 @@
     methods: {
     },
     computed: {
-      identity() {
-        return this.$store.state.identity
+      fingerprint() {
+        return this.$store.state.fingerprint
       },
       currentChat() {
         return this.$store.state.currentChat

--- a/axolotl-web/src/store/store.js
+++ b/axolotl-web/src/store/store.js
@@ -16,10 +16,7 @@ export default new Vuex.Store({
     darkMode: false,
     error: null,
     errorConnection: null,
-    identity: {
-      me: null,
-      their: null
-    },
+    fingerprint: null,
     config: {},
     loginError: null,
     ratelimitError: null,
@@ -195,9 +192,8 @@ export default new Vuex.Store({
       state.contactsFilterd = [];
       state.contactsFilterActive = false;
     },
-    SET_IDENTITY(state, identity) {
-      state.identity.me = identity.Identity;
-      state.identity.their = identity.TheirId;
+    SET_FINGERPRINT(state, message) {
+      state.fingerprint = message.Fingerprint;
     },
     LEAVE_CHAT(state) {
       state.currentGroup = null;
@@ -253,8 +249,8 @@ export default new Vuex.Store({
         else if (Object.keys(messageData)[0] == "CurrentChat") {
           this.commit("SET_CURRENT_CHAT", messageData["CurrentChat"]);
         }
-        else if (Object.keys(messageData)[0] == "Identity") {
-          this.commit("SET_IDENTITY", messageData);
+        else if (Object.keys(messageData)[0] == "Fingerprint") {
+          this.commit("SET_FINGERPRINT", messageData);
         }
         else if (Object.keys(messageData)[0] == "Type") {
           this.commit("SET_REQUEST", messageData);


### PR DESCRIPTION
Hi nanu-c,

this is my code to show the fingerprint in the axolotl client.
This implements the enhancement issue #88.

I made things a bit different than you did this morning and I am not entirely sure that I got the merge right.

My changes depend on https://github.com/signal-golang/textsecure/pull/19.

Please give feedback.

Best Regards

Blackoverflow