### PR TITLE
Link to build script instead of having it in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,54 +75,8 @@ That way running the backend is avoided, instead your current registration on ub
 
 Build Axolotl for all arches with clickable and snap
 ------------
-requires clickable and snapcraft to be installed
-```
-go clean
-
-echo "Build ut linux armhf"
-clickable clean build
-
-echo "Build linux amd64 snap"
-mkdir -p build/linux-amd64-snap
-snapcraft clean axolotl
-snapcraft
-mv *.snap build/linux-amd64-snap/
-
-echo "Build linux amd64"
-mkdir -p build/linux-amd64/axolotl-web
-env GOOS=linux GOARCH=amd64 go build -o build/linux-amd64/axolotl .
-cp axolotl-web/dist build/linux-amd64/axolotl-web -r
-
-echo "Build linux arm5"
-mkdir -p build/linux-arm5/axolotl-web
-env GOOS=linux GOARCH=arm GOARM=5 go build -o build/linux-arm5/axolotl .
-cp axolotl-web/dist build/linux-arm5/axolotl-web -r
-
-echo "Build linux arm7"
-mkdir -p build/linux-arm7/axolotl-web
-env GOOS=linux GOARCH=arm GOARM=7 go build -o build/linux-arm7/axolotl .
-cp axolotl-web/dist build/linux-arm7/axolotl-web -r
-
-echo "Build linux arm64"
-mkdir -p build/linux-arm64/axolotl-web
-env GOOS=linux GOARCH=arm64 go build -o build/linux-arm64/axolotl .
-cp axolotl-web/dist build/linux-arm64/axolotl-web -r
-
-echo "Build windows amd64"
-mkdir -p build/windows-amd64/axolotl-web
-env GOOS=windows GOARCH=amd64 go build -ldflags -H=windowsgui -o build/windows-amd64/axolotl.exe .
-cp axolotl-web/dist build/windows-amd64/axolotl-web -r
-
-echo "Build windows 386"
-mkdir -p build/windows-386/axolotl-web
-env GOOS=windows GOARCH=386 go build -ldflags -H=windowsgui -o build/windows-386/axolotl.exe .
-cp axolotl-web/dist build/windows-amd64/axolotl-web -r
-
-echo "Build darwin amd64"
-mkdir -p build/darwin-amd64/axolotl-web
-env GOOS=darwin GOARCH=amd64 go build -o build/darwin-amd64/axolotl .
-cp axolotl-web/dist build/darwin-amd64/axolotl-web -r
-```
+This requires clickable and snapcraft to be installed
+see [build.sh](scripts/build.sh)
 
 Installation on UT
 ------------


### PR DESCRIPTION
Instead of providing the bash script which can be used to build `axolotl` with snapcraft and clickable both the main readme and in the /scripts directory, link it from the readme.

This creates a single source of truth, provides less overhead, and leaves the main readme for documentation purposes.

This is related to #185.