### PR TITLE
Avoid white flick when launching the app

### DIFF
--- a/axolotl-web/public/index.html
+++ b/axolotl-web/public/index.html
@@ -8,6 +8,19 @@
     <title>axolotl-web</title>
   </head>
   <body>
+    <div id="initial-loader" style="position: fixed; top:0; left: 0; bottom: 0; right: 0; z-index: 2000; background-color: #2090ea; display: flex; justify-content: center; align-items:center;">
+      <!--  SVG by Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL  -->
+      <svg width="38" height="38" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#fff">
+        <g fill="none" fill-rule="evenodd">
+            <g transform="translate(1 1)" stroke-width="2">
+                <circle stroke-opacity=".5" cx="18" cy="18" r="18"></circle>
+                <path d="M36 18c0-9.94-8.06-18-18-18">
+                    <animateTransform attributeName="transform" type="rotate" from="0 18 18" to="360 18 18" dur="1s" repeatCount="indefinite"></animateTransform>
+                </path>
+            </g>
+        </g>
+      </svg>
+    </div>
     <noscript>
       <strong>We're sorry but axolotl-web doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>

--- a/axolotl-web/src/App.vue
+++ b/axolotl-web/src/App.vue
@@ -56,14 +56,11 @@ html,
 body,
 #app {
   height: 100%;
-}
-#app {
   font-family:"ubuntu";
   display: flex;
   flex-direction: column;
 }
 main {
-  height: calc(100% - 50px); /* This is needed for Ubuntu Touch because the Blink engine is too old (chrome 61). */
   overflow: auto;
 }
 

--- a/axolotl-web/src/App.vue
+++ b/axolotl-web/src/App.vue
@@ -61,6 +61,7 @@ body,
   flex-direction: column;
 }
 main {
+  height: calc(100% - 50px); /* This is needed for Ubuntu Touch because the Blink engine is too old (chrome 61). */
   overflow: auto;
 }
 

--- a/axolotl-web/src/pages/ChatList.vue
+++ b/axolotl-web/src/pages/ChatList.vue
@@ -64,8 +64,6 @@ export default {
   props: {
     msg: String
   },
-  created(){
-  },
   mounted(){
     this.$store.dispatch("getChatList");
     document.body.scrollTop = 0;
@@ -77,7 +75,11 @@ export default {
     this.$store.dispatch("clearMessageList");
     this.$store.dispatch("clearFilterContacts");
     this.$store.dispatch("getConfig");
-    this.$store.dispatch("getContacts")
+    this.$store.dispatch("getContacts");
+    let loader = document.getElementById('initial-loader');
+    if (loader != undefined) {
+      loader.remove();
+    }
   },
   data() {
     return {

--- a/axolotl-web/src/pages/Password.vue
+++ b/axolotl-web/src/pages/Password.vue
@@ -20,7 +20,6 @@ export default {
     },
     unregister(){
       this.$store.dispatch("unregister");
-
     }
   },
   data() {
@@ -30,6 +29,10 @@ export default {
   },
   mounted(){
     document.getElementById("passwordInput").focus();
+    let loader = document.getElementById('initial-loader');
+    if (loader != undefined) {
+      loader.remove();
+    }
   },
   computed: {
     error () {

--- a/axolotl-web/src/pages/Register.vue
+++ b/axolotl-web/src/pages/Register.vue
@@ -61,6 +61,10 @@ export default {
     var userLang = navigator.language || navigator.userLanguage;
     this.$language.current = userLang;
     document.getElementById("VuePhoneNumberInput_phone_number").focus();
+    let loader = document.getElementById('initial-loader');
+    if (loader != undefined) {
+      loader.remove();
+    }
   },
   data() {
     return {


### PR DESCRIPTION
Display a loading above everything else and then remove it once the chatList or the registration page is ready. Is there other entry points?