### PR TITLE
Allow downloading build artifacts from GitHub pipeline

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -28,6 +28,12 @@ jobs:
       - name: Build
         run: go build -v
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: axolotl-${{ matrix.os }}-${{ github.run_number }}
+          path: axolotl
+
   build-axolotl-web:
     runs-on: ubuntu-latest
 
@@ -51,3 +57,9 @@ jobs:
 
       - name: Build
         run: npm --prefix ./axolotl-web run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: axolotl-web-${{ github.run_number }}
+          path: axolotl-web/dist/


### PR DESCRIPTION
This addition allows for anyone with write permissions to the repository to download the built artefacts.
The artefacts are built already, this just allows them to be downloaded.

There should be four artefacts:

- axolotl-windows
- axolotl-mac
- axolotl-linux
- axolotl-web

https://github.com/marketplace/actions/upload-a-build-artifact#where-does-the-upload-go