### PR TITLE
Add GitHub CI packaging for x86_64 AppImage

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -90,10 +90,10 @@ jobs:
           rm -rf build/AppDir
 
           mkdir -p build/AppDir/usr/bin
-          cp -f /bin/axolotl-ubuntu-latest-* build/AppDir/usr/bin/axolotl
+          cp -f /bin/axolotl-ubuntu-latest-*/axolotl build/AppDir/usr/bin/axolotl
 
           mkdir -p build/AppDir/usr/bin/axolotl-web
-          cp -rf /bin/axolotl-web-*/dist build/AppDir/usr/bin/axolotl-web
+          cp -rf /bin/axolotl-web-* build/AppDir/usr/bin/axolotl-web
 
           cp -f appimage/AppDir/AppRun build/AppDir/AppRun
           cp -f appimage/AppDir/axolotl.desktop build/AppDir/axolotl.desktop

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -89,6 +89,8 @@ jobs:
           chmod +x appimagetool-x86_64.AppImage
 
       - name: create an AppImage
+        env:
+          ARCH: x86_64
         run: |
           rm -rf build/AppDir
 

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -91,7 +91,6 @@ jobs:
         run: |
           curl -sLO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod +x appimagetool-x86_64.AppImage
-          ln -s appimagetool-x86_64.AppImage /usr/bin/appimagetool
 
       - name: create an AppImage
         run: |
@@ -110,7 +109,7 @@ jobs:
           mkdir -p build/AppDir/usr/share/metainfo
           cp -f appimage/AppDir/axolotl.appdata.xml build/AppDir/usr/share/metainfo/axolotl.appdata.xml
 
-          appimagetool build/AppDir
+          ./appimagetool-x86_64.AppImage build/AppDir
 
       - name: Display AppImage files
         run: |

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -92,7 +92,7 @@ jobs:
           cp -f bin/axolotl-ubuntu-latest-${{ github.run_number }}/axolotl build/AppDir/usr/bin/axolotl
 
           mkdir -p build/AppDir/usr/bin/axolotl-web
-          cp -rf bin/axolotl-web-${{ github.run_number }}/axolotl-web build/AppDir/usr/bin/axolotl-web
+          cp -rf bin/axolotl-web-${{ github.run_number }}/* build/AppDir/usr/bin/axolotl-web
 
           cp -f appimage/AppDir/AppRun build/AppDir/AppRun
           cp -f appimage/AppDir/axolotl.desktop build/AppDir/axolotl.desktop

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -72,33 +72,27 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Download build artifacts
+      - name: Download axolotl and axolotl-web build artifacts
         uses: actions/download-artifact@v2
         with:
           path: bin
-
-      - name: Display axolotl files
-        run: |
-          ls -la ./bin
-          ls -la ./bin/axolotl-*
-          ls -la ./bin/axolotl-web*
 
       - name: Setup appimagetool
         run: |
           curl -sLO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod +x appimagetool-x86_64.AppImage
 
-      - name: create an AppImage
+      - name: Build the AppImage
         env:
           ARCH: x86_64
         run: |
           rm -rf build/AppDir
 
           mkdir -p build/AppDir/usr/bin
-          cp -f ./bin/axolotl-ubuntu-latest-*/axolotl build/AppDir/usr/bin/axolotl
+          cp -f ./bin/axolotl-ubuntu-latest-${{ github.run_number }}/axolotl build/AppDir/usr/bin/axolotl
 
           mkdir -p build/AppDir/usr/bin/axolotl-web
-          cp -rf ./bin/axolotl-web-* build/AppDir/usr/bin/axolotl-web
+          cp -rf ./bin/axolotl-web-${{ github.run_number }} build/AppDir/usr/bin/axolotl-web
 
           cp -f appimage/AppDir/AppRun build/AppDir/AppRun
           cp -f appimage/AppDir/axolotl.desktop build/AppDir/axolotl.desktop
@@ -109,7 +103,8 @@ jobs:
 
           ./appimagetool-x86_64.AppImage build/AppDir
 
-      - name: Display AppImage files
-        run: |
-          ls -R
-          pwd
+      - name: Upload the built AppImage artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: Axolotl-x86_64-${{ github.run_number }}.AppImage
+            path: Axolotl-x86_64.AppImage

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -111,7 +111,6 @@ jobs:
           cp -f appimage/AppDir/axolotl.appdata.xml build/AppDir/usr/share/metainfo/axolotl.appdata.xml
 
           appimagetool build/AppDir
-        working-directory: appimage/
 
       - name: Display AppImage files
         run: |

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -90,6 +90,7 @@ jobs:
         run: |
           mkdir -p build/AppDir/usr/bin
           cp -f bin/axolotl-ubuntu-latest-${{ github.run_number }}/axolotl build/AppDir/usr/bin/axolotl
+          chmod +x build/AppDir/usr/bin/axolotl
 
           mkdir -p build/AppDir/usr/bin/axolotl-web/dist
           cp -rf bin/axolotl-web-${{ github.run_number }}/* build/AppDir/usr/bin/axolotl-web/dist

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -90,10 +90,10 @@ jobs:
           rm -rf build/AppDir
 
           mkdir -p build/AppDir/usr/bin
-          cp -f axolotl build/AppDir/usr/bin/axolotl
+          cp -f /bin/axolotl-ubuntu-latest-* build/AppDir/usr/bin/axolotl
 
           mkdir -p build/AppDir/usr/bin/axolotl-web
-          cp -rf axolotl-web/dist build/AppDir/usr/bin/axolotl-web
+          cp -rf /bin/axolotl-web-*/dist build/AppDir/usr/bin/axolotl-web
 
           cp -f appimage/AppDir/AppRun build/AppDir/AppRun
           cp -f appimage/AppDir/axolotl.desktop build/AppDir/axolotl.desktop

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           name: axolotl-${{ matrix.os }}-${{ github.run_number }}
           path: axolotl
+          retention-days: 1
 
   build-axolotl-web:
     runs-on: ubuntu-latest
@@ -63,6 +64,7 @@ jobs:
         with:
           name: axolotl-web-${{ github.run_number }}
           path: axolotl-web/dist/
+          retention-days: 1
 
   package:
     needs: [build-axolotl, build-axolotl-web]
@@ -89,10 +91,10 @@ jobs:
           rm -rf build/AppDir
 
           mkdir -p build/AppDir/usr/bin
-          cp -f ./bin/axolotl-ubuntu-latest-${{ github.run_number }}/axolotl build/AppDir/usr/bin/axolotl
+          cp -f bin/axolotl-ubuntu-latest-${{ github.run_number }}/axolotl build/AppDir/usr/bin/axolotl
 
           mkdir -p build/AppDir/usr/bin/axolotl-web
-          cp -rf ./bin/axolotl-web-${{ github.run_number }} build/AppDir/usr/bin/axolotl-web
+          cp -rf bin/axolotl-web-${{ github.run_number }} build/AppDir/usr/bin/axolotl-web
 
           cp -f appimage/AppDir/AppRun build/AppDir/AppRun
           cp -f appimage/AppDir/axolotl.desktop build/AppDir/axolotl.desktop
@@ -101,6 +103,8 @@ jobs:
           mkdir -p build/AppDir/usr/share/metainfo
           cp -f appimage/AppDir/axolotl.appdata.xml build/AppDir/usr/share/metainfo/axolotl.appdata.xml
 
+          ls -laR build/AppDir
+
           ./appimagetool-x86_64.AppImage build/AppDir
 
       - name: Upload the built AppImage artifact
@@ -108,3 +112,4 @@ jobs:
         with:
           name: Axolotl-x86_64-${{ github.run_number }}.AppImage
           path: Axolotl-x86_64.AppImage
+          retention-days: 1

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -104,7 +104,7 @@ jobs:
           ./appimagetool-x86_64.AppImage build/AppDir
 
       - name: Upload the built AppImage artifact
-          uses: actions/upload-artifact@v2
-          with:
-            name: Axolotl-x86_64-${{ github.run_number }}.AppImage
-            path: Axolotl-x86_64.AppImage
+        uses: actions/upload-artifact@v2
+        with:
+          name: Axolotl-x86_64-${{ github.run_number }}.AppImage
+          path: Axolotl-x86_64.AppImage

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -78,7 +78,10 @@ jobs:
           path: bin
 
       - name: Display axolotl files
-        run: ls -R
+        run: |
+          ls -la ./bin
+          ls -la ./bin/axolotl-*
+          ls -la ./bin/axolotl-web*
 
       - name: Setup appimagetool
         run: |
@@ -90,10 +93,10 @@ jobs:
           rm -rf build/AppDir
 
           mkdir -p build/AppDir/usr/bin
-          cp -f /bin/axolotl-ubuntu-latest-*/axolotl build/AppDir/usr/bin/axolotl
+          cp -f ./bin/axolotl-ubuntu-latest-*/axolotl build/AppDir/usr/bin/axolotl
 
           mkdir -p build/AppDir/usr/bin/axolotl-web
-          cp -rf /bin/axolotl-web-* build/AppDir/usr/bin/axolotl-web
+          cp -rf ./bin/axolotl-web-* build/AppDir/usr/bin/axolotl-web
 
           cp -f appimage/AppDir/AppRun build/AppDir/AppRun
           cp -f appimage/AppDir/axolotl.desktop build/AppDir/axolotl.desktop

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -63,3 +63,26 @@ jobs:
         with:
           name: axolotl-web-${{ github.run_number }}
           path: axolotl-web/dist/
+
+  package:
+    needs: [build-axolotl, build-axolotl-web]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download axolotl build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: axolotl
+
+      - name: Download axolotl-web build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: axolotl-web
+
+      - name: Display axolotl files
+        run: ls -R
+        working-directory: axolotl/
+
+      - name: Display axolotl-web files
+        run: ls -R
+        working-directory: axolotl-web/

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -88,13 +88,11 @@ jobs:
         env:
           ARCH: x86_64
         run: |
-          rm -rf build/AppDir
-
           mkdir -p build/AppDir/usr/bin
           cp -f bin/axolotl-ubuntu-latest-${{ github.run_number }}/axolotl build/AppDir/usr/bin/axolotl
 
           mkdir -p build/AppDir/usr/bin/axolotl-web
-          cp -rf bin/axolotl-web-${{ github.run_number }} build/AppDir/usr/bin/axolotl-web
+          cp -rf bin/axolotl-web-${{ github.run_number }}/axolotl-web build/AppDir/usr/bin/axolotl-web
 
           cp -f appimage/AppDir/AppRun build/AppDir/AppRun
           cp -f appimage/AppDir/axolotl.desktop build/AppDir/axolotl.desktop

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -91,10 +91,12 @@ jobs:
           mkdir -p build/AppDir/usr/bin
           cp -f bin/axolotl-ubuntu-latest-${{ github.run_number }}/axolotl build/AppDir/usr/bin/axolotl
 
-          mkdir -p build/AppDir/usr/bin/axolotl-web
-          cp -rf bin/axolotl-web-${{ github.run_number }}/* build/AppDir/usr/bin/axolotl-web
+          mkdir -p build/AppDir/usr/bin/axolotl-web/dist
+          cp -rf bin/axolotl-web-${{ github.run_number }}/* build/AppDir/usr/bin/axolotl-web/dist
 
           cp -f appimage/AppDir/AppRun build/AppDir/AppRun
+          chmod +x build/AppDir/AppRun
+
           cp -f appimage/AppDir/axolotl.desktop build/AppDir/axolotl.desktop
           cp -f appimage/AppDir/axolotl.png build/AppDir/axolotl.png
 

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -4,6 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   build-axolotl:
+    name: Build axolotl
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +37,7 @@ jobs:
           retention-days: 1
 
   build-axolotl-web:
+    name: Build axolotl-web
     runs-on: ubuntu-latest
 
     steps:
@@ -66,7 +68,8 @@ jobs:
           path: axolotl-web/dist/
           retention-days: 1
 
-  package:
+  package-appimage:
+    name: Package as an AppImage
     needs: [build-axolotl, build-axolotl-web]
     runs-on: ubuntu-latest
 
@@ -103,8 +106,6 @@ jobs:
 
           mkdir -p build/AppDir/usr/share/metainfo
           cp -f appimage/AppDir/axolotl.appdata.xml build/AppDir/usr/share/metainfo/axolotl.appdata.xml
-
-          ls -laR build/AppDir
 
           ./appimagetool-x86_64.AppImage build/AppDir
 

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -69,6 +69,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
       - name: Download axolotl build artifacts
         uses: actions/download-artifact@v2
         with:
@@ -80,9 +83,37 @@ jobs:
           path: axolotl-web
 
       - name: Display axolotl files
-        run: ls -R
-        working-directory: axolotl/
+        run: |
+          ls -R
+          pwd
 
-      - name: Display axolotl-web files
-        run: ls -R
-        working-directory: axolotl-web/
+      - name: Setup appimagetool
+        run: |
+          curl -sLO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x appimagetool-x86_64.AppImage
+          ln -s appimagetool-x86_64.AppImage /usr/bin/appimagetool
+
+      - name: create an AppImage
+        run: |
+          rm -rf build/AppDir
+
+          mkdir -p build/AppDir/usr/bin
+          cp -f axolotl build/AppDir/usr/bin/axolotl
+
+          mkdir -p build/AppDir/usr/bin/axolotl-web
+          cp -rf axolotl-web/dist build/AppDir/usr/bin/axolotl-web
+
+          cp -f appimage/AppDir/AppRun build/AppDir/AppRun
+          cp -f appimage/AppDir/axolotl.desktop build/AppDir/axolotl.desktop
+          cp -f appimage/AppDir/axolotl.png build/AppDir/axolotl.png
+
+          mkdir -p build/AppDir/usr/share/metainfo
+          cp -f appimage/AppDir/axolotl.appdata.xml build/AppDir/usr/share/metainfo/axolotl.appdata.xml
+
+          appimagetool build/AppDir
+        working-directory: appimage/
+
+      - name: Display AppImage files
+        run: |
+          ls -R
+          pwd

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up Go 1.15
+      - name: Setup Go 1.15
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
@@ -72,20 +72,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Download axolotl build artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          path: axolotl
-
-      - name: Download axolotl-web build artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: axolotl-web
+          path: bin
 
       - name: Display axolotl files
-        run: |
-          ls -R
-          pwd
+        run: ls -R
 
       - name: Setup appimagetool
         run: |


### PR DESCRIPTION
This PR adds a pipeline step to build an `AppImage` using the already built `axolotl` and `axolotl-web` files.

It builds an AppImage for x86_64, this could probably be expanded upon.
Which other Linux architectures would we want to target?

Link from GitHub regarding who can see, and where to find the build artifacts:
https://github.com/marketplace/actions/upload-a-build-artifact#where-does-the-upload-go

Now when we know how to manage pipeline artifacts, this could possibly be used to later als build flatpak and clickable install files.