### PR TITLE
Improve the build and installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,6 @@ To find out how to build and install, please see below:
 * with Flatpak: see [here](docs/INSTALL.md#flatpak).
 * with AppImage: see [here](docs/INSTALL.md#appimage).
 
-Build Axolotl for all arches with clickable and snap
-------------
-This requires clickable and snapcraft to be installed
-see [build.sh](scripts/build.sh)
 
 Run flags
 -----------

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ To use it from your Ubuntu Touch device, simply install it from the open store:
 Axolotl is also available as a snap package, to install it on Ubuntu desktop:  
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/axolotl)
 
-[![Snap Status](https://build.snapcraft.io/badge/nanu-c/axolotl.svg)](https://build.snapcraft.io/user/nanu-c/axolotl)
-
 What works
 -----------
 
@@ -66,22 +64,21 @@ That way running the backend is avoided, instead your current registration on ub
 * `cd axolotl-web`
 * `VUE_APP_WS_ADDRESS=10.0.0.2 npm run serve` replace 10.0.0.2 with the ip of your phone
 
+Installation 
+------------
+Axolotl can be built and installed in different ways.
+
+To find out how to build and install, please see below:
+
+* with Clickable: see [here](docs/INSTALL.md#clickable).
+* with Snap: see [here](docs/INSTALL.md#snap).
+* with Flatpak: see [here](docs/INSTALL.md#flatpak).
+* with AppImage: see [here](docs/INSTALL.md#appimage).
+
 Build Axolotl for all arches with clickable and snap
 ------------
 This requires clickable and snapcraft to be installed
 see [build.sh](scripts/build.sh)
-
-Installation on UT
-------------
-
-***If you want to use the current stable version, simply install it from the OpenStore***
-
-The build-system is now integrated in the `clickable` Version 3.2.0.
-* primary steps from installation
-* Get [clickable](https://github.com/bhdouglass/clickable#install)
-* Run `clickable`, this also transfers the click package to the Ubuntu Touch Phone
-* Run `clickable launch logs` to start signal and watch the log
-
 
 Run flags
 -----------

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -31,11 +31,16 @@ To install all go dependencies, use `go mod download`.
 To run the default set of sub-commands, simply run clickable in the root directory.
 Clickable will attempt to auto detect the build template and other configuration options.
 
+This also transfers the click package to the Ubuntu Touch Phone.
+
 `clickable`
 
 **Run**
 
 `clickable launch`
+
+Clickable supports a few different parameters.
+For example, `clickable launch logs` to start signal and get logging output.
 
 For a full list of available clickable commands, see [here](https://clickable-ut.dev/en/latest/commands.html).
 
@@ -43,23 +48,31 @@ For a full list of available clickable commands, see [here](https://clickable-ut
 
 **Tooling**
 
-This requires `snapcraft` to be installed locally.
-Installation instructions can be found [here](https://snapcraft.io/docs/getting-started).
+This requires `snap` and `snapcraft` to be installed locally.
+Installation instructions for snapcraft can be found [here](https://snapcraft.io/docs/getting-started).
 
 **Dependencies**
 
-TODO: Add more info
+Snapcraft manages its own dependencies.
 
 **Build and Install**
 
 The Snap template used for the installation can be found
 in the /snap subdirectory.
 
-TODO: Add more info
+To build the application, use the following command from the root of this repository.
+
+`sudo snapcraft`
+
+To install the built snap, use snap:
+
+`sudo snap install axolotl_0.8.9_amd64.snap --dangerous`
 
 **Run**
 
-TODO: Add more info
+To start the application, either search for "Axolotl" in your app drawer or start it with the below command.
+
+`snap run axolotl`
 
 ## Flatpak
 
@@ -122,5 +135,6 @@ cd appimage
 **Run**
 
 To start the application, execute the AppImage binary directly:
+If needed, set the file as executable with `chmod +x Axolotl-x86_64.AppImage` first.
 
 `./Axolotl-x86_64.AppImage`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -138,3 +138,9 @@ To start the application, execute the AppImage binary directly:
 If needed, set the file as executable with `chmod +x Axolotl-x86_64.AppImage` first.
 
 `./Axolotl-x86_64.AppImage`
+
+## Build Axolotl for all arches with clickable and snap
+
+This requires clickable and snapcraft to be installed.
+It also requires the axolotl-web bundle to already be built.
+see [build.sh](../scripts/build.sh)


### PR DESCRIPTION
This PR lists the different packaging options available in the main readme.

It further adds missing details regarding the `snapcraft` tool to the installation document.

I see this relevant for #185.