### PR TITLE
Allow to prepare an Axolotl release through GitHub CI

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -70,6 +70,8 @@ jobs:
 
   package-appimage:
     name: Package as an AppImage
+    # This ensures that this job only runs on git tags
+    if: startsWith(github.ref, "refs/tags/v")
     needs: [build-axolotl, build-axolotl-web]
     runs-on: ubuntu-latest
 
@@ -135,14 +137,14 @@ jobs:
         run: |
           echo "VERSION=${{ steps.get_version.outputs.version }}" >> $GITHUB_ENV
 
+      - name: Create zip archive of repo
+        run: |
+          zip -r ./build-artifacts/sources.zip ./
+
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
           path: build-artifacts
-
-      - name: Create zip archive of repo
-        run: |
-          zip -r ./build-artifacts/sources.zip ./ --exclude ./build-artifacts
 
       - name: Create draft GitHub release page
         id: create_release

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -134,7 +134,6 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          RELEASE_VERSION: ${{ steps.git_tag.outputs.tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -112,6 +112,48 @@ jobs:
       - name: Upload the built AppImage artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Axolotl-x86_64-${{ github.run_number }}.AppImage
+          name: Axolotl-x86_64-${{ github.run_number }}
           path: Axolotl-x86_64.AppImage
           retention-days: 1
+
+  release:
+    needs: [package-appimage]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: build-artifacts
+
+      - name: Create GitHub release
+        # if: github.ref == 'refs/heads/main'
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          RELEASE_VERSION: ${{ steps.git_tag.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: |
+            -
+            -
+          draft: true
+          prerelease: false
+
+      - name: Upload release assets
+        # if: github.ref == 'refs/heads/main'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # This pulls from the step above, referencing it's ID to get its outputs object,
+          # which includes an `upload_url`.
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build-artifacts/Axolotl-x86_64-${{ github.run_number }}/Axolotl-x86_64.AppImage
+          asset_name: Axolotl-x86_64.AppImage
+          asset_content_type: application/vnd.appimage

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Set git tag version
         run: |
-          echo ::set-env name=VERSION::${{ steps.get_version.outputs.version }}
+          echo "VERSION=${{ steps.get_version.outputs.version }}" >> $GITHUB_ENV
 
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -150,8 +150,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${VERSION}
-          release_name: ${VERSION}
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
           body: |
             -
             -
@@ -165,7 +165,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build-artifacts/sources.zip
-          asset_name: sources-${VERSION}.zip
+          asset_name: sources-${{ env.VERSION }}.zip
           asset_content_type: application/zip
 
       - name: Add AppImage to release
@@ -175,5 +175,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build-artifacts/Axolotl-AppImage/Axolotl-x86_64.AppImage
-          asset_name: Axolotl-${VERSION}-x86_64.AppImage
+          asset_name: Axolotl-${{ env.VERSION }}-x86_64.AppImage
           asset_content_type: application/vnd.appimage

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: axolotl-${{ matrix.os }}-${{ github.run_number }}
+          name: axolotl-${{ matrix.os }}
           path: axolotl
           retention-days: 1
 
@@ -64,7 +64,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: axolotl-web-${{ github.run_number }}
+          name: axolotl-web
           path: axolotl-web/dist/
           retention-days: 1
 
@@ -112,7 +112,7 @@ jobs:
       - name: Upload the built AppImage artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Axolotl-x86_64-${{ github.run_number }}
+          name: Axolotl-AppImage
           path: Axolotl-x86_64.AppImage
           retention-days: 1
 
@@ -129,8 +129,13 @@ jobs:
         with:
           path: build-artifacts
 
-      - name: Create GitHub release
-        # if: github.ref == 'refs/heads/main'
+      - name: Create zip archives for release page from build artifacts
+        run: |
+          zip -r ./build-artifacts/axolotl.zip ./build-artifacts/axolotl/*
+          zip -r ./build-artifacts/axolotl-web.zip ./build-artifacts/axolotl-web/*
+
+      - name: Create draft GitHub release page
+        # if: startsWith(github.ref, "refs/tags/")
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -144,15 +149,35 @@ jobs:
           draft: true
           prerelease: false
 
-      - name: Upload release assets
-        # if: github.ref == 'refs/heads/main'
+      - name: Add axolotl sources to release
+        # if: startsWith(github.ref, "refs/tags/")
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # This pulls from the step above, referencing it's ID to get its outputs object,
-          # which includes an `upload_url`.
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build-artifacts/Axolotl-x86_64-${{ github.run_number }}/Axolotl-x86_64.AppImage
+          asset_path: ./build-artifacts/axolotl.zip
+          asset_name: axolotl.zip
+          asset_content_type: application/zip
+
+      - name: Add axolotl-web sources to release
+        # if: startsWith(github.ref, "refs/tags/")
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build-artifacts/axolotl-web.zip
+          asset_name: axolotl-web.zip
+          asset_content_type: application/zip
+
+      - name: Add AppImage file to release
+        # if: startsWith(github.ref, "refs/tags/")
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build-artifacts/Axolotl-AppImage/Axolotl-x86_64.AppImage
           asset_name: Axolotl-x86_64.AppImage
           asset_content_type: application/vnd.appimage

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -137,14 +137,14 @@ jobs:
         run: |
           echo "VERSION=${{ steps.get_version.outputs.version }}" >> $GITHUB_ENV
 
-      - name: Create zip archive of repo
-        run: |
-          zip -r ./build-artifacts/sources.zip ./
-
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
           path: build-artifacts
+
+      - name: Create zip archive of repo
+        run: |
+          zip -r ./build-artifacts/sources.zip ./ --exclude ./build-artifacts
 
       - name: Create draft GitHub release page
         id: create_release

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -92,11 +92,11 @@ jobs:
           ARCH: x86_64
         run: |
           mkdir -p build/AppDir/usr/bin
-          cp -f bin/axolotl-ubuntu-latest-${{ github.run_number }}/axolotl build/AppDir/usr/bin/axolotl
+          cp -f bin/axolotl-ubuntu-latest/axolotl build/AppDir/usr/bin/axolotl
           chmod +x build/AppDir/usr/bin/axolotl
 
           mkdir -p build/AppDir/usr/bin/axolotl-web/dist
-          cp -rf bin/axolotl-web-${{ github.run_number }}/* build/AppDir/usr/bin/axolotl-web/dist
+          cp -rf bin/axolotl-web/* build/AppDir/usr/bin/axolotl-web/dist
 
           cp -f appimage/AppDir/AppRun build/AppDir/AppRun
           chmod +x build/AppDir/AppRun
@@ -129,10 +129,9 @@ jobs:
         with:
           path: build-artifacts
 
-      - name: Create zip archives for release page from build artifacts
+      - name: Create zip archive of repo
         run: |
-          zip -r ./build-artifacts/axolotl.zip ./build-artifacts/axolotl/*
-          zip -r ./build-artifacts/axolotl-web.zip ./build-artifacts/axolotl-web/*
+          zip -r ./build-artifacts/sources.zip ./ --exclude ./build-artifacts
 
       - name: Create draft GitHub release page
         # if: startsWith(github.ref, "refs/tags/")
@@ -156,22 +155,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build-artifacts/axolotl.zip
-          asset_name: axolotl.zip
+          asset_path: ./build-artifacts/sources.zip
+          asset_name: sources.zip
           asset_content_type: application/zip
 
-      - name: Add axolotl-web sources to release
-        # if: startsWith(github.ref, "refs/tags/")
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build-artifacts/axolotl-web.zip
-          asset_name: axolotl-web.zip
-          asset_content_type: application/zip
-
-      - name: Add AppImage file to release
+      - name: Add AppImage to release
         # if: startsWith(github.ref, "refs/tags/")
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -117,12 +117,23 @@ jobs:
           retention-days: 1
 
   release:
+    name: Create release
+    # This ensures that this job only runs on git tags
+    # if: startsWith(github.ref, "refs/tags/v")
     needs: [package-appimage]
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+
+      - name: Get git tag version
+        id: get_version
+        uses: battila7/get-version-action@v2
+
+      - name: Set git tag version
+        run: |
+          echo ::set-env name=VERSION::${{ steps.get_version.outputs.version }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -134,14 +145,13 @@ jobs:
           zip -r ./build-artifacts/sources.zip ./ --exclude ./build-artifacts
 
       - name: Create draft GitHub release page
-        # if: startsWith(github.ref, "refs/tags/")
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${VERSION}
+          release_name: ${VERSION}
           body: |
             -
             -
@@ -149,23 +159,21 @@ jobs:
           prerelease: false
 
       - name: Add axolotl sources to release
-        # if: startsWith(github.ref, "refs/tags/")
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build-artifacts/sources.zip
-          asset_name: sources.zip
+          asset_name: sources-${VERSION}.zip
           asset_content_type: application/zip
 
       - name: Add AppImage to release
-        # if: startsWith(github.ref, "refs/tags/")
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build-artifacts/Axolotl-AppImage/Axolotl-x86_64.AppImage
-          asset_name: Axolotl-x86_64.AppImage
+          asset_name: Axolotl-${VERSION}-x86_64.AppImage
           asset_content_type: application/vnd.appimage

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -119,7 +119,7 @@ jobs:
   release:
     name: Create release
     # This ensures that this job only runs on git tags
-    # if: startsWith(github.ref, "refs/tags/v")
+    if: startsWith(github.ref, "refs/tags/v")
     needs: [package-appimage]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This MR expands the previous CI solution and adds an automatic GitHub release page alongside with AppImage and sources when a git tag is pushed.

The release page is prepared and a zip file of the repo source files as well as the built AppImage are added, however no automatic release is done. The page is set as Draft.