### PR TITLE
Mobian installer link added

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ To find out how to build and install, please see below:
 * with Snap: see [here](docs/INSTALL.md#snap).
 * with Flatpak: see [here](docs/INSTALL.md#flatpak).
 * with AppImage: see [here](docs/INSTALL.md#appimage).
+* for Mobian: see [here](https://github.com/nuehm-arno/axolotl-mobian-installer).
 
 
 Run flags


### PR DESCRIPTION
A simple link to the installer repo should be easier to maintain.