### PR TITLE
Add a --version flag to axolotl

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Run flags
     `me` -> qmlscene,
     `server` -> just run the webserver. Defaults to run with `electron`.
 * `-eDebug` show developer console in electron mode
+* `-version` Print version info
 * `-host` Set the host to run the webserver from. Defaults to localhost.
 * `-port` Set the port to run the webserver from. Defaults to 9080.
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"runtime"
 
 	log "github.com/sirupsen/logrus"
 
@@ -14,9 +15,9 @@ import (
 	"github.com/signal-golang/textsecure"
 )
 
-var AppName = "textsecure.nanuc"
+const AppName = "textsecure.nanuc"
 
-var AppVersion = "0.9.9"
+const AppVersion = "0.9.9"
 
 // Do not allow sending attachments larger than 100M for now
 var MaxAttachmentSize int64 = 100 * 1024 * 1024
@@ -27,6 +28,7 @@ var (
 	MainQml                string
 	Gui                    string
 	ElectronDebug          bool
+	PrintVersion           bool
 	HomeDir                string
 	ConfigDir              string
 	CacheDir               string
@@ -84,6 +86,12 @@ func SetupConfig() {
 	if len(flag.Args()) == 1 {
 		TsDeviceURL = flag.Arg(0)
 	}
+
+	if PrintVersion {
+        fmt.Printf("%s %s %s %s %s\n",
+                    AppName, AppVersion, runtime.GOOS, runtime.GOARCH, runtime.Version())
+        os.Exit(0)
+    }
 
 	if IsPushHelper || IsPhone{
 		log.Printf("[axolotl] use push helper")

--- a/main.go
+++ b/main.go
@@ -25,9 +25,10 @@ var e string
 
 func init() {
 	flag.StringVar(&config.MainQml, "qml", "qml/phoneui/main.qml", "The qml file to load.")
-	flag.StringVar(&config.Gui, "e", "", "use either electron, ut, lorca, qt or server")
+	flag.StringVar(&config.Gui, "e", "", "Specify runtime environment. Use either electron, ut, lorca, qt or server")
 	flag.StringVar(&config.AxolotlWebDir, "axolotlWebDir", "./axolotl-web/dist", "Specify the directory to use for axolotl-web")
-	flag.BoolVar(&config.ElectronDebug, "eDebug", false, "use to show development console in electron")
+	flag.BoolVar(&config.ElectronDebug, "eDebug", false, "Open electron development console")
+	flag.BoolVar(&config.PrintVersion, "version", false, "Print version info")
 	flag.StringVar(&config.ServerHost, "host", "127.0.0.1", "Host to serve UI from.")
 	flag.StringVar(&config.ServerPort, "port", "9080", "Port to serve UI from.")
 }


### PR DESCRIPTION
Add a --version flag to axolotl.

Also reword the help text for some existing flags.

```
./axolotl --version
textsecure.nanuc 0.9.9 linux amd64 go1.15.8
```

```
./axolotl --help
Usage of ./axolotl:
  -axolotlWebDir string
    	Specify the directory to use for axolotl-web (default "./axolotl-web/dist")
  -e string
    	Specify runtime environment. Use either electron, ut, lorca, qt or server
  -eDebug
    	Open electron development console
  -host string
    	Host to serve UI from. (default "127.0.0.1")
  -port string
    	Port to serve UI from. (default "9080")
  -qml string
    	The qml file to load. (default "qml/phoneui/main.qml")
  -version
    	Print version info
```

This closes #409 
