### PR TITLE
readme: List all installation methods in the same section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,7 @@ It is built upon the [Go textsecure package](https://github.com/nanu-c/textsecur
   </kbd>
 </p>
 
-To use it from your Ubuntu Touch device, simply install it from the open store:  
-[![OpenStore](https://open-store.io/badges/en_US.png)](https://open-store.io/app/textsecure.nanuc)
-
-Axolotl is also available as a snap package, to install it on Ubuntu desktop:  
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/axolotl)
-
-What works
------------
+## What works
 
  * Phone registration
  * Contact discovery
@@ -32,8 +25,7 @@ What works
  * Encrypted message store
  * Desktop client provisioning/syncing *partially*
 
-What is missing
----------------
+## What is missing
 
  * Push notifications
  * Most settings that are available in the Android app
@@ -41,8 +33,26 @@ What is missing
 
 There are still bugs and UI/UX quirks.
 
-Installation of development environment
-------------
+## Installation
+
+Axolotl can be built and installed in different ways.
+
+To use it from your Ubuntu Touch device, simply install it from the open store:  
+[![OpenStore](https://open-store.io/badges/en_US.png)](https://open-store.io/app/textsecure.nanuc)
+
+Axolotl is also available as a snap package, to install it on Ubuntu desktop:  
+[![Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/axolotl)
+
+To find out how to build and install, please see below:
+
+* with Clickable: see [here](docs/INSTALL.md#clickable).
+* with Snap: see [here](docs/INSTALL.md#snap).
+* with Flatpak: see [here](docs/INSTALL.md#flatpak).
+* with AppImage: see [here](docs/INSTALL.md#appimage).
+* for Mobian: see [here](docs/INSTALL.md#mobian).
+
+## Installation of development environment
+
 * Install [Golang](https://golang.org/doc/install)
 * Install node js (see the [.nvmrc](axolotl-web/.nvmrc)) file for the supported version
 * Add gopath to ~/.bashrc https://github.com/golang/go/wiki/SettingGOPATH
@@ -56,34 +66,21 @@ When setting up for the first time and maybe occasionally later you need to upda
 
 `npx browserslist@latest --update-db`
 
-Run development
-------------
+## Run development
+
 * `cd $(go env GOPATH)/src/github.com/nanu-c/axolotl`
 * `go run .`
 * in a new terminal `cd axolotl-web && npm run serve`
 * point a browser to the link printed in the terminal  like `http://localhost:9080`
 
-Run frontend and connect to phone ip
---------------
+## Run frontend and connect to phone ip
+
 That way running the backend is avoided, instead your current registration on ubuntu touch is used
 * `cd axolotl-web`
 * `VUE_APP_WS_ADDRESS=10.0.0.2 npm run serve` replace 10.0.0.2 with the ip of your phone
 
-Installation
-------------
-Axolotl can be built and installed in different ways.
+## Run flags
 
-To find out how to build and install, please see below:
-
-* with Clickable: see [here](docs/INSTALL.md#clickable).
-* with Snap: see [here](docs/INSTALL.md#snap).
-* with Flatpak: see [here](docs/INSTALL.md#flatpak).
-* with AppImage: see [here](docs/INSTALL.md#appimage).
-* for Mobian: see [here](docs/INSTALL.md#mobian).
-
-
-Run flags
------------
 * `-axolotlWebDir` Specify the directory to use for axolotl-web. Defaults to "./axolotl-web/dist".
 * `-e` for either
     `lorca`-> native chromium (has to be installed),
@@ -95,15 +92,15 @@ Run flags
 * `-host` Set the host to run the webserver from. Defaults to localhost.
 * `-port` Set the port to run the webserver from. Defaults to 9080.
 
-Environment variables
------------
+## Environment variables
+
 * `AXOLOTL_WEB_DIR` Specify the directory to use for axolotl-web. This is used by `axolotl` during startup.
 * `AXOLOTL_GUI_DIR` Specifies the directory used for GUI specifications. This is used by `axolotl` only when in `qt` mode.
 
-Contributing
------------
+## Contributing
+
 * Please fill issues here on github https://github.com/nanu-c/axolotl/issues
-* Help translating Axolotl to your language(s). For information how to translate, please see [TRANSLATE.md](docs/TRANSLATE.md).
+* Help translate Axolotl to your language(s). For information how to translate, please see [TRANSLATE.md](docs/TRANSLATE.md).
 * Contribute code by making PR's (pull requests)
 
 If you contribute new strings, please:
@@ -118,7 +115,6 @@ examples:
 - `<p><strong v-translate>Translate me!</strong></p>` instead of `<p v-translate><strong>Translate me!</strong></p>`
 - `<p v-translate>Translate me!</p><br/><p v-translate> Please...</p>` instead of `<p v-translate>Translate me! <br/> Please...</p>`
 
-Migrating from `janimo/axolotl`
---------------------------------------
+## Migrating from `janimo/axolotl`
 
 For information how to migrate from `janimo/axolotl`, please see [MIGRATE.md](docs/MIGRATE.md).

--- a/appimage/AppDir/axolotl.appdata.xml
+++ b/appimage/AppDir/axolotl.appdata.xml
@@ -23,7 +23,7 @@
     <screenshots>
         <screenshot type="default">
             <caption>Axolotl screenshot</caption>
-            <image>https://github.com/nanu-c/axolotl/blob/main/screenshot.png</image>
+            <image>https://raw.githubusercontent.com/nanu-c/axolotl/main/screenshot.png</image>
         </screenshot>
     </screenshots>
     <releases>

--- a/flatpak/org.nanuc.Axolotl.appdata.xml
+++ b/flatpak/org.nanuc.Axolotl.appdata.xml
@@ -23,7 +23,7 @@
     <screenshots>
         <screenshot type="default">
             <caption>Axolotl screenshot</caption>
-            <image>https://github.com/nanu-c/axolotl/blob/main/screenshot.png</image>
+            <image>https://raw.githubusercontent.com/nanu-c/axolotl/main/screenshot.png</image>
         </screenshot>
     </screenshots>
     <releases>


### PR DESCRIPTION
Move OpenStore and Snap Store links to the installation section.

Set the unified installation section as the third block in the main readme.

Migrate all headers to use hash-style markup as to allow for (future) sub-sections (using ### for example).

Also small fix for AppImage and Flatpak metadata screenshot URL, as the previous link didnt work for FlatHub