### PR TITLE
Upgrade axolotl to go 1.16

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup Go 1.15
+      - name: Setup Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nanu-c/axolotl
 
-go 1.15
+go 1.16
 
 require (
 	github.com/asticode/go-astikit v0.17.0 // indirect


### PR DESCRIPTION
This updates go.mod and the CI to use go v1.16 instead of 1.15.

This closes #417