### PR TITLE
Add initial Makefile for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,30 @@ GO=$(shell which go)
 all: clean build run
 
 .PHONY: build
-build:
-	$(GO) build -v .
+build: build-axolotl-web build-axolotl
+
+.PHONY: build-axolotl-web
+build-axolotl-web:
 	$(NPM) run build --prefix axolotl-web
+
+.PHONY: build-axolotl
+build-axolotl:
+	$(GO) build -v .
 
 .PHONY: run
 run: build
 	$(GO) run .
 
-.PHONY: build-deps
-build-deps:
-	$(GO) mod download
+.PHONY: build-dependencies
+build-dependencies: build-dependencies-axolotl-web build-dependencies-axolotl
+
+.PHONY: build-dependencies-axolotl-web
+build-dependencies-axolotl-web:
 	$(NPM) install --prefix axolotl-web
+
+.PHONY: build-dependencies-axolotl
+build-dependencies-axolotl:
+	$(GO) mod download
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ build:
 run: build
 	$(GO) run .
 
+.PHONY: build-deps
+build-deps:
+	$(GO) mod download
+	$(NPM) install --prefix axolotl-web
+
 .PHONY: clean
 clean:
 	rm -f axolotl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# This is the Makefile for axolotl.
+# For more info about the syntax, see https://makefiletutorial.com/
+
+EXECUTABLES = go npm
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $(exec)),,$(error "No $(exec) in PATH")))
+
+NPM=$(shell which npm)
+GO=$(shell which go)
+
+.PHONY: all
+all: clean build run
+
+.PHONY: build
+build:
+	$(GO) build -v .
+	$(NPM) run build --prefix axolotl-web
+
+.PHONY: run
+run: build
+	$(GO) run .
+
+.PHONY: clean
+clean:
+	rm -f axolotl
+	rm -rf axolotl-web/dist

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
 # This is the Makefile for axolotl.
 # For more info about the syntax, see https://makefiletutorial.com/
 
-EXECUTABLES = go npm node
-K := $(foreach exec,$(EXECUTABLES),\
-        $(if $(shell which $(exec)),,$(error "No $(exec) in PATH")))
-
 NPM=$(shell which npm)
 GO=$(shell which go)
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 NPM_VERSION := $(shell npm --version 2>/dev/null)
 NODE_VERSION := $(shell node --version 2>/dev/null)
 GO_VERSION := $(shell go version 2>/dev/null)
+HARDWARE_PLATFORM := $(shell uname --machine)
 
 NPM=$(shell which npm)
 GO=$(shell which go)
@@ -31,6 +32,16 @@ build-dependencies-axolotl-web:
 
 build-dependencies-axolotl:
 	$(GO) mod download
+ifeq ($(HARDWARE_PLATFORM), x86_64)
+	wget https://raw.githubusercontent.com/nanu-c/zkgroup/main/lib/libzkgroup_linux_amd64.so
+else ifeq ($(HARDWARE_PLATFORM), aarch64)
+	wget https://raw.githubusercontent.com/nanu-c/zkgroup/main/lib/libzkgroup_linux_arm64.so
+else ifeq ($(HARDWARE_PLATFORM), armhf)
+	wget https://raw.githubusercontent.com/nanu-c/zkgroup/main/lib/libzkgroup_linux_armhf.so
+else
+	@echo architecture not supported
+	exit 1
+endif
 
 clean:
 	rm -f axolotl

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This is the Makefile for axolotl.
 # For more info about the syntax, see https://makefiletutorial.com/
 
-EXECUTABLES = go npm
+EXECUTABLES = go npm node
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $(exec)),,$(error "No $(exec) in PATH")))
 

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,37 @@
 # This is the Makefile for axolotl.
 # For more info about the syntax, see https://makefiletutorial.com/
 
+NPM_VERSION := $(shell npm --version 2>/dev/null)
+NODE_VERSION := $(shell node --version 2>/dev/null)
+GO_VERSION := $(shell go version 2>/dev/null)
+
 NPM=$(shell which npm)
 GO=$(shell which go)
 
-.PHONY: all
 all: clean build run
 
-.PHONY: build
 build: build-axolotl-web build-axolotl
 
-.PHONY: build-axolotl-web
 build-axolotl-web:
 	$(NPM) run build --prefix axolotl-web
 
-.PHONY: build-axolotl
 build-axolotl:
 	$(GO) build -v .
 
-.PHONY: run
+build-translation:
+	$(NPM) run translate --prefix axolotl-web
+
 run: build
 	$(GO) run .
 
-.PHONY: build-dependencies
 build-dependencies: build-dependencies-axolotl-web build-dependencies-axolotl
 
-.PHONY: build-dependencies-axolotl-web
 build-dependencies-axolotl-web:
 	$(NPM) install --prefix axolotl-web
 
-.PHONY: build-dependencies-axolotl
 build-dependencies-axolotl:
 	$(GO) mod download
 
-.PHONY: clean
 clean:
 	rm -f axolotl
 	rm -rf axolotl-web/dist

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 NPM_VERSION := $(shell npm --version 2>/dev/null)
 NODE_VERSION := $(shell node --version 2>/dev/null)
 GO_VERSION := $(shell go version 2>/dev/null)
-HARDWARE_PLATFORM := $(shell uname --machine)
 
 NPM=$(shell which npm)
 GO=$(shell which go)
@@ -32,16 +31,6 @@ build-dependencies-axolotl-web:
 
 build-dependencies-axolotl:
 	$(GO) mod download
-ifeq ($(HARDWARE_PLATFORM), x86_64)
-	wget https://raw.githubusercontent.com/nanu-c/zkgroup/main/lib/libzkgroup_linux_amd64.so
-else ifeq ($(HARDWARE_PLATFORM), aarch64)
-	wget https://raw.githubusercontent.com/nanu-c/zkgroup/main/lib/libzkgroup_linux_arm64.so
-else ifeq ($(HARDWARE_PLATFORM), armhf)
-	wget https://raw.githubusercontent.com/nanu-c/zkgroup/main/lib/libzkgroup_linux_armhf.so
-else
-	@echo architecture not supported
-	exit 1
-endif
 
 clean:
 	rm -f axolotl


### PR DESCRIPTION
As the title says, add a minimal Makefile to wire up both the backend and the frontend.

This aims to lower the barrier for getting started with a local development setup.

With this, once go and npm/node are installed, one only need to do a one-off `make build-dependencies` and then subsequently `make`.

Should we also add any other targets?
I am also asking myself, if what is the best scope for the `.all` target. Maybe build and run is enough? Or is it worth it, always start by removing the old build artifacts.
