### PR TITLE
Build Flatpak bundle and clickables for each Pull Request

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -74,7 +74,7 @@ jobs:
           retention-days: 1
 
   package-appimage:
-    name: Package as an AppImage
+    name: Package as AppImage
     # This ensures that this job only runs on git tags
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-axolotl, build-axolotl-web]

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -1,6 +1,12 @@
 name: Axolotl pipeline
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v
+  pull_request:
 
 jobs:
   build-axolotl:
@@ -119,8 +125,6 @@ jobs:
 
   package-clickable:
     name: Package as clickables
-    # This ensures that this job only runs on git tags
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
 
     steps:
@@ -163,11 +167,30 @@ jobs:
           path: build/arm-linux-gnueabihf/app/textsecure.nanuc_*.click
           retention-days: 1
 
+  package-flatpak:
+    name: Package as Flatpak bundle
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:freedesktop-20.08
+      options: --privileged
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - uses: bilelmoussaoui/flatpak-github-actions@v2
+        with:
+          bundle: "axolotl.flatpak"
+          manifest-path: "flatpak/web/org.nanuc.Axolotl.yml"
+          branch: "main"
+
   release:
     name: Create release
     # This ensures that this job only runs on git tags
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [package-appimage, package-clickable]
+    needs:
+      - package-appimage
+      - package-clickable
     runs-on: ubuntu-latest
 
     steps:

--- a/flatpak/qt/org.nanuc.Axolotl.yml
+++ b/flatpak/qt/org.nanuc.Axolotl.yml
@@ -10,7 +10,7 @@ command: axolotl
 base: io.qt.qtwebengine.BaseApp
 base-version: "5.15"
 tags:
-  - nightly
+  - latest
 finish-args:
   # See https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html
   # Write access for the user download folder (to save media)

--- a/flatpak/qt/org.nanuc.Axolotl.yml
+++ b/flatpak/qt/org.nanuc.Axolotl.yml
@@ -9,6 +9,8 @@ sdk-extensions:
 command: axolotl
 base: io.qt.qtwebengine.BaseApp
 base-version: "5.15"
+tags:
+  - nightly
 finish-args:
   # See https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html
   # Write access for the user download folder (to save media)

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -8,7 +8,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node14
 command: axolotl
 tags:
-  - nightly
+  - latest
 finish-args:
   # See https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html
   # Write access for the user download folder (to save media)

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -7,6 +7,8 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
   - org.freedesktop.Sdk.Extension.node14
 command: axolotl
+tags:
+  - nightly
 finish-args:
   # See https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html
   # Write access for the user download folder (to save media)


### PR DESCRIPTION
* Build a Flatpak bundle for each pull request.
* Build clickable install artifacts for each pull request (as per discussion on Axolotl-dev)

Refine the Workflow starting rules: now the CI is only ran on commits to a pull request, a version tag or for the main branch.

Add Flatpak tag for "latest" versions: this as to differ them from the "stable" Flathub manifest release.

Thanks to @bilelmoussaoui for making some great github actions.
https://github.com/bilelmoussaoui/flatpak-github-actions