### PR TITLE
Add logging for astilectron creation step

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func runElectron() {
 	if len(electronPath) == 0 {
 		electronPath = config.ConfigDir + "/electron"
 	}
-	var a, err = astilectron.New(l, astilectron.Options{
+	var a, initErr = astilectron.New(l, astilectron.Options{
 		AppName:            "axolotl",
 		AppIconDefaultPath: "axolotl-web/public/axolotl.png", // If path is relative, it must be relative to the data directory
 		AppIconDarwinPath:  "axolotl-web/public/axolotl.png", // Same here
@@ -80,7 +80,7 @@ func runElectron() {
 		SingleInstance:     true,
 		ElectronSwitches:   []string{"--disable-dev-shm-usage", "--no-sandbox"}})
 
-	if err != nil {
+	if initErr != nil {
 	  log.Errorln(errors.Wrap(err, "[axolotl-electron]: creating astilectron failed"))
   }
 

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func runElectron() {
 	if len(electronPath) == 0 {
 		electronPath = config.ConfigDir + "/electron"
 	}
-	var a, initErr = astilectron.New(l, astilectron.Options{
+	a, err := astilectron.New(l, astilectron.Options{
 		AppName:            "axolotl",
 		AppIconDefaultPath: "axolotl-web/public/axolotl.png", // If path is relative, it must be relative to the data directory
 		AppIconDarwinPath:  "axolotl-web/public/axolotl.png", // Same here
@@ -80,8 +80,8 @@ func runElectron() {
 		SingleInstance:     true,
 		ElectronSwitches:   []string{"--disable-dev-shm-usage", "--no-sandbox"}})
 
-	if initErr != nil {
-	  log.Errorln(errors.Wrap(initErr, "[axolotl-electron]: creating astilectron failed"))
+	if err != nil {
+	  log.Errorln(errors.Wrap(err, "[axolotl-electron]: creating astilectron failed"))
   }
 
 	defer a.Close()
@@ -89,7 +89,7 @@ func runElectron() {
 	// Start astilectron
 	a.HandleSignals()
 
-	if err := a.Start(); err != nil {
+	if err = a.Start(); err != nil {
 		log.Errorln(errors.Wrap(err, "[axolotl-electron] main: starting astilectron failed"))
 	}
 

--- a/main.go
+++ b/main.go
@@ -100,7 +100,6 @@ func runElectron() {
 	a.HandleSignals()
 	// New window
 	var w *astilectron.Window
-	var err error
 	center := true
 	height := 800
 	width := 600

--- a/main.go
+++ b/main.go
@@ -70,14 +70,19 @@ func runElectron() {
 	if len(electronPath) == 0 {
 		electronPath = config.ConfigDir + "/electron"
 	}
-	var a, _ = astilectron.New(l, astilectron.Options{
+	var a, err = astilectron.New(l, astilectron.Options{
 		AppName:            "axolotl",
 		AppIconDefaultPath: "axolotl-web/public/axolotl.png", // If path is relative, it must be relative to the data directory
 		AppIconDarwinPath:  "axolotl-web/public/axolotl.png", // Same here
 		BaseDirectoryPath:  electronPath,
 		VersionElectron:    "12.0.0",
+		VersionAstilectron: "0.45.0",
 		SingleInstance:     true,
 		ElectronSwitches:   []string{"--disable-dev-shm-usage", "--no-sandbox"}})
+
+	if err != nil {
+	  log.Errorln(errors.Wrap(err, "[axolotl-electron]: creating astilectron failed"))
+  }
 
 	defer a.Close()
 
@@ -85,7 +90,7 @@ func runElectron() {
 	a.HandleSignals()
 
 	if err := a.Start(); err != nil {
-		log.Debugln(errors.Wrap(err, "[axolotl-electron] main: starting astilectron failed"))
+		log.Errorln(errors.Wrap(err, "[axolotl-electron] main: starting astilectron failed"))
 	}
 
 	a.On(astilectron.EventNameAppCrash, func(e astilectron.Event) (deleteListener bool) {

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func runElectron() {
 		ElectronSwitches:   []string{"--disable-dev-shm-usage", "--no-sandbox"}})
 
 	if initErr != nil {
-	  log.Errorln(errors.Wrap(err, "[axolotl-electron]: creating astilectron failed"))
+	  log.Errorln(errors.Wrap(initErr, "[axolotl-electron]: creating astilectron failed"))
   }
 
 	defer a.Close()

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func runElectron() {
 	if len(electronPath) == 0 {
 		electronPath = config.ConfigDir + "/electron"
 	}
-	a, err := astilectron.New(l, astilectron.Options{
+	var a, err = astilectron.New(l, astilectron.Options{
 		AppName:            "axolotl",
 		AppIconDefaultPath: "axolotl-web/public/axolotl.png", // If path is relative, it must be relative to the data directory
 		AppIconDarwinPath:  "axolotl-web/public/axolotl.png", // Same here


### PR DESCRIPTION
Reading some of the recent GitHub issues, there seems to be some problem coming from the electron download done during the initial startup.

This PR adds logging for the astilectron instatiation step.

The change is based on the go-astilectron example https://github.com/asticode/go-astilectron/blob/master/example/main.go#L16.
Where previously the second return object from `astilectron.New` was not used, it is now.
Furthermore, the log level of any astilectron startup issues is adjusted from debug to error.

We now also explicitly specify which Astilectron version to download. The version specified, is the version which was already used: this is just to explicitly specify a version rather than relying on the "latest".