### PR TITLE
Add Electron base to axolotl Flatpak web-version

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -96,6 +96,7 @@ flatpak install org.freedesktop.Platform//20.08
 flatpak install org.freedesktop.Sdk//20.08
 flatpak install org.freedesktop.Sdk.Extension.golang//20.08
 flatpak install org.freedesktop.Sdk.Extension.node14//20.08
+flatpak install io.atom.electron.BaseApp//20.08
 ```
 
 **Build and Install**

--- a/flatpak/qt/org.nanuc.Axolotl.yml
+++ b/flatpak/qt/org.nanuc.Axolotl.yml
@@ -8,7 +8,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node14
 command: axolotl
 base: io.qt.qtwebengine.BaseApp
-base-version: "5.15"
+base-version: '5.15'
 tags:
   - latest
 finish-args:

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -7,6 +7,8 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
   - org.freedesktop.Sdk.Extension.node14
 command: axolotl
+base: io.atom.electron.BaseApp
+base-version: '20.08'
 tags:
   - latest
 finish-args:


### PR DESCRIPTION
Add the Electron base app to the flatpak web-manifest for Axolotl.

This aligns the snap with the flatpak in terms of packaging.

It should also be more reliable then depending on the Electron download at runtime.

Once this is merged, I would put the same edits in place in the FlatHub repo.

This could potentially solve some of the issues in https://github.com/nanu-c/axolotl/issues/433 - however further changes might be needed as well.