### PR TITLE
Add Axolotl version update util

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ update-version:
 ifeq ($(NEW_VERSION),)
 	@echo Please specify the new version to use! Example: "make prepare-release NEW_VERSION=0.9.10"
 else
-		@echo Replacing current version $(AXOLOTL_VERSION) with new version $(NEW_VERSION)
-		@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' manifest.json
-		@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' app/config/config.go
-		@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' snap/snapcraft.yaml
-		@sed -i "32i $$APPDATA_TEXT" appimage/AppDir/axolotl.appdata.xml
-		@sed -i "32i $$APPDATA_TEXT" flatpak/org.nanuc.Axolotl.appdata.xml
-		@echo Update complete
+	@echo Replacing current version $(AXOLOTL_VERSION) with new version $(NEW_VERSION)
+	@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' manifest.json
+	@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' app/config/config.go
+	@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' snap/snapcraft.yaml
+	@sed -i "32i $$APPDATA_TEXT" appimage/AppDir/axolotl.appdata.xml
+	@sed -i "32i $$APPDATA_TEXT" flatpak/org.nanuc.Axolotl.appdata.xml
+	@echo Update complete
 endif

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,15 @@
 NPM_VERSION := $(shell npm --version 2>/dev/null)
 NODE_VERSION := $(shell node --version 2>/dev/null)
 GO_VERSION := $(shell go version 2>/dev/null)
+AXOLOTL_GIT_VERSION := $(shell git tag | tail --lines=1)
+AXOLOTL_VERSION := $(subst v,,$(AXOLOTL_GIT_VERSION))
+
+define APPDATA_TEXT=
+\\t\t\t<release version="$(NEW_VERSION)" date="$(shell date --rfc-3339='date')">\n\
+\t\t\t\t\t<url>https://github.com/nanu-c/axolotl/releases/tag/v$(NEW_VERSION)</url>\n\
+\t\t\t</release>
+endef
+export APPDATA_TEXT
 
 NPM=$(shell which npm)
 GO=$(shell which go)
@@ -35,3 +44,16 @@ build-dependencies-axolotl:
 clean:
 	rm -f axolotl
 	rm -rf axolotl-web/dist
+
+update-version:
+ifeq ($(NEW_VERSION),)
+	@echo Please specify the new version to use! Example: "make prepare-release NEW_VERSION=0.9.10"
+else
+		@echo Replacing current version $(AXOLOTL_VERSION) with new version $(NEW_VERSION)
+		@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' manifest.json
+		@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' app/config/config.go
+		@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' snap/snapcraft.yaml
+		@sed -i "32i $$APPDATA_TEXT" appimage/AppDir/axolotl.appdata.xml
+		@sed -i "32i $$APPDATA_TEXT" flatpak/org.nanuc.Axolotl.appdata.xml
+		@echo Update complete
+endif


### PR DESCRIPTION
As to ease new releases, a little helper util to update all version numbers used across the project, as well as to update the appdata XMLs.

Example usage: `make update-version NEW_VERSION=0.9.10`