### PR TITLE
Add Flatpak install and setup targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ export APPDATA_TEXT
 
 NPM=$(shell which npm)
 GO=$(shell which go)
+FLATPAK=$(shell which flatpak)
+FLATPAK_BUILDER=$(shell which flatpak-builder)
 
 all: clean build run
 
@@ -47,7 +49,7 @@ clean:
 
 update-version:
 ifeq ($(NEW_VERSION),)
-	@echo Please specify the new version to use! Example: "make prepare-release NEW_VERSION=0.9.10"
+	@echo Please specify the new version to use! Example: "make update-version NEW_VERSION=0.9.10"
 else
 	@echo Replacing current version $(AXOLOTL_VERSION) with new version $(NEW_VERSION)
 	@sed -i 's/$(AXOLOTL_VERSION)/$(NEW_VERSION)/' manifest.json
@@ -57,3 +59,23 @@ else
 	@sed -i "32i $$APPDATA_TEXT" flatpak/org.nanuc.Axolotl.appdata.xml
 	@echo Update complete
 endif
+
+build-dependencies-flatpak:
+	$(FLATPAK) install org.freedesktop.Sdk.Extension.golang//20.08
+	$(FLATPAK) install org.freedesktop.Sdk.Extension.node14//20.08
+
+build-dependencies-flatpak-web: build-dependencies-flatpak
+	$(FLATPAK) install org.freedesktop.Platform//20.08
+	$(FLATPAK) install org.freedesktop.Sdk//20.08
+	$(FLATPAK) install io.atom.electron.BaseApp//20.08
+
+build-dependencies-flatpak-qt: build-dependencies-flatpak
+	$(FLATPAK) install org.kde.Platform//5.15
+	$(FLATPAK) install org.kde.Sdk//5.15
+	$(FLATPAK) install io.qt.qtwebengine.BaseApp//5.15
+
+install-flatpak-web:
+	$(FLATPAK_BUILDER) --user --install build flatpak/web/org.nanuc.Axolotl.yml
+
+install-flatpak-qt:
+	$(FLATPAK_BUILDER) --user --install build flatpak/qt/org.nanuc.Axolotl.yml


### PR DESCRIPTION
commands > documentation.

This PR takes the already existing documentation regarding Flatpak and their installation, and just makes it executable.