### PR TITLE
Add Makefile check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,14 @@ build-axolotl:
 build-translation:
 	$(NPM) run translate --prefix axolotl-web
 
+check: check-axolotl check-axolotl-web
+
+check-axolotl-web:
+	$(NPM) run test --prefix axolotl-web
+
+check-axolotl:
+	$(GO) test -race ./...
+
 run: build
 	$(GO) run .
 

--- a/axolotl-web/package.json
+++ b/axolotl-web/package.json
@@ -11,6 +11,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "test": "echo 'No tests available' && exit 0",
     "depcheck": "depcheck",
     "translate": "npm run translate-extract && npm run translate-update && npm run translate-compile",
     "translate-compile": "npm run translate-remove-tmp&&node ./node_modules/easygettext/src/compile-cli.js --output ./translations/translations.json $(find ../po/ -type f -name '*.po')",


### PR DESCRIPTION
Turns out, there are some standard Makefile targets.

One of them is `check`. This seems to be used for automatic testing of the software, which once we have it implemented, this target will execute.

One got to start somewhere, right?