### PR TITLE
Add initial Makefile install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ NODE_VERSION := $(shell node --version 2>/dev/null)
 GO_VERSION := $(shell go version 2>/dev/null)
 AXOLOTL_GIT_VERSION := $(shell git tag | tail --lines=1)
 AXOLOTL_VERSION := $(subst v,,$(AXOLOTL_GIT_VERSION))
+CURRENT_DIR = $(shell pwd)
 
 define APPDATA_TEXT=
 \\t\t\t<release version="$(NEW_VERSION)" date="$(shell date --rfc-3339='date')">\n\
@@ -20,6 +21,13 @@ GO=$(shell which go)
 all: clean build run
 
 build: build-axolotl-web build-axolotl
+
+install: install-axolotl-web install-axolotl
+	@sudo install -D -m 644 $(CURRENT_DIR)/scripts/axolotl.desktop /usr/share/applications/axolotl.desktop
+	@sudo install -D -m 644 $(CURRENT_DIR)/snap/gui/axolotl.png /usr/share/icons/hicolor/128x128/apps/axolotl.png
+
+uninstall:
+	@sudo rm -rf /usr/bin/axolotl
 
 build-axolotl-web:
 	$(NPM) run build --prefix axolotl-web
@@ -40,6 +48,12 @@ build-dependencies-axolotl-web:
 
 build-dependencies-axolotl:
 	$(GO) mod download
+
+install-axolotl-web: build-axolotl-web
+	@sudo cp -r $(CURRENT_DIR)/axolotl-web/dist /usr/bin/axolotl/axolotl-web/dist
+
+install-axolotl: build-axolotl
+	@sudo install -D -m 755 $(CURRENT_DIR)/axolotl /usr/bin/axolotl
 
 clean:
 	rm -f axolotl

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -231,3 +231,16 @@ sh mobian_installer.sh
 ```
 
 To check out, what the script does exactly or to execute commands separately, visit the [Mobian wiki page for Axolotl](https://wiki.mobian-project.org/doku.php?id=axolotl) - section Manual Installation.
+
+## Bare
+
+**Tooling**
+
+This requires `make`, `go`, `nodejs` and `npm` to be installed locally.
+For the required versions, see [go.mod](../go.mod) and [package.json](../axolotl-web/package.json)
+
+**Build and Install**
+
+To install, simply use the makefile target `install`.
+
+`make install`

--- a/scripts/axolotl.desktop
+++ b/scripts/axolotl.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Axolotl
+GenericName=Signal Chat Client
+Exec=/usr/bin/axolotl %U
+Type=Application
+Icon=axolotl
+Comment=A signal client
+Categories=Network;InstantMessaging;Chat;
+Terminal=false


### PR DESCRIPTION
For someone who doesnt want to install axolotl with clickable, Snap, Flatpak, or AppImage, now one can also install the whole application with just the Makefile. Got to have all the options, right?

This target does also seem to be one of the standard ones which are present in Makefiles.