### PR TITLE
[axolotl-web] Review AddContact(Modal) component linter warnings

### DIFF
--- a/axolotl-web/src/components/AddContactModal.vue
+++ b/axolotl-web/src/components/AddContactModal.vue
@@ -18,7 +18,7 @@
         </div>
         <div class="modal-body">
           <div class="form-group">
-            <label v-translate for="inputPhone">Name</label>
+            <label v-translate for="nameInput">Name</label>
             <input
               id="nameInput"
               v-model="name"
@@ -27,7 +27,7 @@
             >
           </div>
           <div class="form-group">
-            <label v-translate for="inputPhone">Phone</label>
+            <label v-translate for="phoneInput">Phone</label>
             <input
               id="phoneInput"
               v-model="phone"

--- a/axolotl-web/src/components/AddContactModal.vue
+++ b/axolotl-web/src/components/AddContactModal.vue
@@ -5,7 +5,7 @@
         <div class="modal-header">
           <h5 class="modal-title">
             <span v-translate>Add</span>
-            <div v-if="name != ''">{{ name }}</div>
+            <div v-if="name !== ''">{{ name }}</div>
             <div v-else v-translate>Contact</div>
           </h5>
           <button type="button" class="close" @click="$emit('close')">
@@ -13,40 +13,36 @@
           </button>
         </div>
         <div class="modal-body">
-          <span
-            ><strong v-translate
-              >Only add numbers that you are sure are registered Signal
-              accounts!</strong
-            ></span
-          >
+          <span><strong v-translate>Only add numbers that you are sure are registered Signal
+            accounts!</strong></span>
         </div>
         <div class="modal-body">
           <div class="form-group">
-            <label for="inputPhone" v-translate>Name</label>
+            <label v-translate for="inputPhone">Name</label>
             <input
+              id="nameInput"
               v-model="name"
               type="text"
               class="form-control"
-              id="nameInput"
-            />
+            >
           </div>
           <div class="form-group">
-            <label for="inputPhone" v-translate>Phone</label>
+            <label v-translate for="inputPhone">Phone</label>
             <input
+              id="phoneInput"
               v-model="phone"
               type="text"
               class="form-control"
-              id="phoneInput"
               placeholder="+44..."
-            />
+            >
           </div>
         </div>
         <div class="modal-footer">
           <button
+            v-translate
             type="button"
             class="btn btn-primary"
             @click="$emit('add', { name: name, phone: phone })"
-            v-translate
           >
             Add
           </button>

--- a/axolotl-web/src/components/AddContactModal.vue
+++ b/axolotl-web/src/components/AddContactModal.vue
@@ -54,7 +54,7 @@
 
 <script>
 export default {
-  name: "AddContact",
+  name: "AddContactModal",
   data() {
     return {
       phone: "",


### PR DESCRIPTION
Follow linter configuration for AddContactModal/AddContact component

Convert == comparisons to === if possible.

My IDE is complaining that the label "for", `inputPhone`, does not exist. (line 21 and 30).

Could it be that the labels should be for the input elements just below them in the template?

Due to this, I believe the first label would be "for" `nameInput`, and the second label for `phoneInput`, and have adjusted the template accordingly.

Is there a specific reason why the component `name` is set to AddContact, and not AddContactModal? For many of the other components, the component name is 1:1 to the file name.