### PR TITLE
[axolotl-web] Registration component

### DIFF
--- a/axolotl-web/src/pages/Register.vue
+++ b/axolotl-web/src/pages/Register.vue
@@ -35,7 +35,7 @@
         id="phoneInput"
         mode="international"
         class="phoneInput"
-        @validate="updatePhone"
+        @input="updatePhone"
       />
       <button v-translate class="btn btn-primary" @click="requestCode()">
         Request code
@@ -81,7 +81,8 @@ export default {
       this.$store.dispatch("requestCode", this.phone.replace(/\s/g, ""));
     },
     updatePhone(e) {
-      this.phone = e.number;
+      if(typeof e =="string")
+      this.phone = e;
     },
     openExtern(e, url) {
       if (this.gui == "ut") {

--- a/axolotl-web/src/pages/Register.vue
+++ b/axolotl-web/src/pages/Register.vue
@@ -2,41 +2,42 @@
   <div class="register">
     <WarningMessage />
     <div v-if="infoPage" class="page1 info">
-      <img class="logo" src="/axolotl.png" />
+      <img class="logo" src="/axolotl.png">
       <h1 class="title">Axolotl Beta</h1>
-      <h2 class="subtitle" v-translate>A cross-plattform signal client</h2>
+      <h2 v-translate class="subtitle">A cross-plattform signal client</h2>
       <div class="description">
         Hey! Mr. Tambourine Man, play a song for me,
-        <br />
+        <br>
         In the jingle jangle morning I'll come following you.
-        <br />
+        <br>
         It's beta, expect lot's of things not working.
-        <br />
+        <br>
         <a
           href="https://axolotl.chat"
           @click="openExtern($event, 'https://axolotl.chat')"
-          >https://axolotl.chat</a
         >
-        <br />
+          https://axolotl.chat
+        </a>
+        <br>
         <font-awesome-icon id="heart" icon="heart" />
       </div>
-      <button class="btn btn-primary" @click="infoPage = false" v-translate>
+      <button v-translate class="btn btn-primary" @click="infoPage = false">
         Next
       </button>
     </div>
-    <div class="rateLimit-error" v-if="ratelimitError != null">
+    <div v-if="ratelimitError != null" class="rateLimit-error">
       <div class="error">
         {{ ratelimitError }}
       </div>
     </div>
     <div v-else class="registration">
       <VueTelInput
-        @validate="updatePhone"
+        id="phoneInput"
         mode="international"
         class="phoneInput"
-        id="phoneInput"
+        @validate="updatePhone"
       />
-      <button class="btn btn-primary" @click="requestCode()" v-translate>
+      <button v-translate class="btn btn-primary" @click="requestCode()">
         Request code
       </button>
     </div>
@@ -50,10 +51,30 @@ import WarningMessage from "@/components/WarningMessage";
 import { mapState } from "vuex";
 
 export default {
-  name: "register",
+  name: "RegisterPage",
   components: {
     VueTelInput,
     WarningMessage,
+  },
+  data() {
+    return {
+      phone: "",
+      infoPage: true,
+    };
+  },
+  computed: mapState([
+    "gui",
+    "ratelimitError",
+    "registrationStatus",
+    "captchaToken",
+    "captchaTokenSent",
+  ]),
+  mounted() {
+    var userLang = navigator.language || navigator.userLanguage;
+    this.$language.current = userLang;
+    if (this.captchaToken != null && !this.captchaTokenSent) {
+      this.$store.dispatch("sendCaptchaToken");
+    }
   },
   methods: {
     requestCode() {
@@ -69,27 +90,6 @@ export default {
       }
     },
   },
-  mounted() {
-    var userLang = navigator.language || navigator.userLanguage;
-    this.$language.current = userLang;
-    if (this.captchaToken != null && !this.captchaTokenSent) {
-      this.$store.dispatch("sendCaptchaToken");
-    }
-  },
-  data() {
-    return {
-      phone: "",
-      infoPage: true,
-    };
-  },
-  computed: mapState([
-    "gui",
-    "ratelimitError",
-    "registrationStatus",
-    "captchaToken",
-    "captchaTokenSent",
-  ]),
-  watch: {},
 };
 </script>
 <style scoped>

--- a/axolotl-web/src/pages/Register.vue
+++ b/axolotl-web/src/pages/Register.vue
@@ -31,8 +31,7 @@
     </div>
     <div v-else class="registration">
       <VueTelInput
-        v-model="phone"
-        @input="updatePhone"
+        @validate="updatePhone"
         mode="international"
         class="phoneInput"
         id="phoneInput"
@@ -56,15 +55,12 @@ export default {
     VueTelInput,
     WarningMessage,
   },
-  props: {
-    msg: String,
-  },
   methods: {
     requestCode() {
       this.$store.dispatch("requestCode", this.phone.replace(/\s/g, ""));
     },
     updatePhone(e) {
-      this.phone = e;
+      this.phone = e.number;
     },
     openExtern(e, url) {
       if (this.gui == "ut") {

--- a/axolotl-web/src/pages/Register.vue
+++ b/axolotl-web/src/pages/Register.vue
@@ -70,9 +70,9 @@ export default {
     "captchaTokenSent",
   ]),
   mounted() {
-    var userLang = navigator.language || navigator.userLanguage;
+    const userLang = navigator.language || navigator.userLanguage;
     this.$language.current = userLang;
-    if (this.captchaToken != null && !this.captchaTokenSent) {
+    if (this.captchaToken !== null && !this.captchaTokenSent) {
       this.$store.dispatch("sendCaptchaToken");
     }
   },
@@ -81,11 +81,11 @@ export default {
       this.$store.dispatch("requestCode", this.phone.replace(/\s/g, ""));
     },
     updatePhone(e) {
-      if(typeof e =="string")
+      if(typeof e === "string")
       this.phone = e;
     },
     openExtern(e, url) {
-      if (this.gui == "ut") {
+      if (this.gui === "ut") {
         e.preventDefault();
         alert(url);
       }


### PR DESCRIPTION
Currently the registration doesn't work on elctron/chromium because the phone number is only returned from the phone input component in `@validate`, whereby it works on firefox. 

This also solves linter errors for that component.