### PR TITLE
Adjust target path for Makefile install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install-axolotl-web: build-axolotl-web
 	@sudo cp -r $(CURRENT_DIR)/axolotl-web/dist /usr/bin/axolotl/axolotl-web/dist
 
 install-axolotl: build-axolotl
-	@sudo install -D -m 755 $(CURRENT_DIR)/axolotl /usr/bin/axolotl
+	@sudo install -D -m 755 $(CURRENT_DIR)/axolotl /usr/bin/axolotl/axolotl
 
 clean:
 	rm -f axolotl


### PR DESCRIPTION
The previous config resulted in one binary file, located at /usr/bin/axolotl.

What we need is an /usr/bin/axolotl folder, which in its turn contains the binary axolotl and the web bundle.