### PR TITLE
Flatpak: Add the required zkgroup dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,10 +163,10 @@ build-dependencies-flatpak-qt: build-dependencies-flatpak
 	$(FLATPAK) install io.qt.qtwebengine.BaseApp//5.15
 
 install-flatpak-web:
-	$(FLATPAK_BUILDER) --user --install build flatpak/web/org.nanuc.Axolotl.yml
+	$(FLATPAK_BUILDER) --user --install --force-clean build flatpak/web/org.nanuc.Axolotl.yml
 
 install-flatpak-qt:
-	$(FLATPAK_BUILDER) --user --install build flatpak/qt/org.nanuc.Axolotl.yml
+	$(FLATPAK_BUILDER) --user --install --force-clean build flatpak/qt/org.nanuc.Axolotl.yml
 
 ## Snap
 build-snap:

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ build-dependencies-flatpak:
 build-dependencies-flatpak-web: build-dependencies-flatpak
 	$(FLATPAK) install org.freedesktop.Platform//20.08
 	$(FLATPAK) install org.freedesktop.Sdk//20.08
-	$(FLATPAK) install io.atom.electron.BaseApp//20.08
+	$(FLATPAK) install org.electronjs.Electron2.BaseApp//20.08
 
 build-dependencies-flatpak-qt: build-dependencies-flatpak
 	$(FLATPAK) install org.kde.Platform//5.15

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -96,7 +96,7 @@ flatpak install org.freedesktop.Platform//20.08
 flatpak install org.freedesktop.Sdk//20.08
 flatpak install org.freedesktop.Sdk.Extension.golang//20.08
 flatpak install org.freedesktop.Sdk.Extension.node14//20.08
-flatpak install io.atom.electron.BaseApp//20.08
+flatpak install org.electronjs.Electron2.BaseApp//20.08
 ```
 
 **Build and Install**

--- a/flatpak/org.nanuc.Axolotl.appdata.xml
+++ b/flatpak/org.nanuc.Axolotl.appdata.xml
@@ -62,17 +62,17 @@
       <release version="0.9.0" date="2020-11-30">
           <url>https://github.com/nanu-c/axolotl/releases/tag/v0.9.0</url>
       </release>
-        <release version="0.8.9" date="2020-10-10">
-            <url>https://github.com/nanu-c/axolotl/releases/tag/v0.8.9</url>
-        </release>
-        <release version="0.8.8" date="2020-10-04">
-            <url>https://github.com/nanu-c/axolotl/releases/tag/v0.8.8</url>
-        </release>
-        <release version="0.8.7" date="2020-09-27">
-            <url>https://github.com/nanu-c/axolotl/releases/tag/v0.8.7</url>
-        </release>
-        <release version="0.8.6" date="2020-08-30">
-            <url>https://github.com/nanu-c/axolotl/releases/tag/v0.8.6</url>
-        </release>
+      <release version="0.8.9" date="2020-10-10">
+          <url>https://github.com/nanu-c/axolotl/releases/tag/v0.8.9</url>
+      </release>
+      <release version="0.8.8" date="2020-10-04">
+          <url>https://github.com/nanu-c/axolotl/releases/tag/v0.8.8</url>
+      </release>
+      <release version="0.8.7" date="2020-09-27">
+          <url>https://github.com/nanu-c/axolotl/releases/tag/v0.8.7</url>
+      </release>
+      <release version="0.8.6" date="2020-08-30">
+          <url>https://github.com/nanu-c/axolotl/releases/tag/v0.8.6</url>
+      </release>
     </releases>
 </component>

--- a/flatpak/qt/org.nanuc.Axolotl.yml
+++ b/flatpak/qt/org.nanuc.Axolotl.yml
@@ -38,6 +38,42 @@ finish-args:
   - --env=AXOLOTL_GUI_DIR=/app/share/axolotl/
 
 modules:
+  - name: zkgroup-x86_64
+    buildsystem: simple
+    only-arches:
+      - x86_64
+    build-commands:
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_amd64.so ${FLATPAK_DEST}/usr/lib"
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/zkgroup
+        tag: main
+        dest: src/github.com/nanu-c/zkgroup
+
+  - name: zkgroup-arm64
+    buildsystem: simple
+    only-arches:
+      - arm64
+    build-commands:
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_arm64.so ${FLATPAK_DEST}/usr/lib"
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/zkgroup
+        tag: main
+        dest: src/github.com/nanu-c/zkgroup
+
+  - name: zkgroup-armhf
+    buildsystem: simple
+    only-arches:
+      - armhf
+    build-commands:
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_armhf.so ${FLATPAK_DEST}/usr/lib"
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/zkgroup
+        tag: main
+        dest: src/github.com/nanu-c/zkgroup
+
   - name: axolotl
     buildsystem: simple
     build-options:
@@ -53,7 +89,7 @@ modules:
       - "install -Dm 755 $(which qmlscene) ${FLATPAK_DEST}/bin"
     sources:
       - type: git
-        url: "https://github.com/nanu-c/axolotl"
+        url: https://github.com/nanu-c/axolotl
         tag: main
         dest: src/github.com/nanu-c/axolotl
 
@@ -71,12 +107,12 @@ modules:
       - "mkdir -p ${FLATPAK_DEST}/bin/axolotl-web"
       - "mkdir -p ${FLATPAK_DEST}/share/axolotl"
       - "cp -r src/github.com/nanu-c/axolotl/axolotl-web/dist ${FLATPAK_DEST}/bin/axolotl-web"
-      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png"
+      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/usr/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png"
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/appdata/${FLATPAK_ID}.appdata.xml"
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/qt/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
       - "cp -r src/github.com/nanu-c/axolotl/guis ${FLATPAK_DEST}/share/axolotl/"
     sources:
       - type: git
-        url: "https://github.com/nanu-c/axolotl"
+        url: https://github.com/nanu-c/axolotl
         tag: main
         dest: src/github.com/nanu-c/axolotl

--- a/flatpak/qt/org.nanuc.Axolotl.yml
+++ b/flatpak/qt/org.nanuc.Axolotl.yml
@@ -43,7 +43,7 @@ modules:
     only-arches:
       - x86_64
     build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_amd64.so ${FLATPAK_DEST}/usr/lib"
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_amd64.so ${FLATPAK_DEST}/lib"
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
@@ -55,7 +55,7 @@ modules:
     only-arches:
       - arm64
     build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_arm64.so ${FLATPAK_DEST}/usr/lib"
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_arm64.so ${FLATPAK_DEST}/lib"
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
@@ -67,7 +67,7 @@ modules:
     only-arches:
       - armhf
     build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_armhf.so ${FLATPAK_DEST}/usr/lib"
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_armhf.so ${FLATPAK_DEST}/lib"
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -7,8 +7,9 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
   - org.freedesktop.Sdk.Extension.node14
 command: axolotl
-base: io.atom.electron.BaseApp
+base: org.electronjs.Electron2.BaseApp
 base-version: '20.08'
+separate-locales: false
 tags:
   - latest
 finish-args:
@@ -37,6 +38,42 @@ finish-args:
   - --env=AXOLOTL_WEB_DIR=/app/bin/axolotl-web/dist
 
 modules:
+  - name: zkgroup-x86_64
+    buildsystem: simple
+    only-arches:
+      - x86_64
+    build-commands:
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_amd64.so ${FLATPAK_DEST}/usr/lib"
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/zkgroup
+        tag: main
+        dest: src/github.com/nanu-c/zkgroup
+
+  - name: zkgroup-arm64
+    buildsystem: simple
+    only-arches:
+      - arm64
+    build-commands:
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_arm64.so ${FLATPAK_DEST}/usr/lib"
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/zkgroup
+        tag: main
+        dest: src/github.com/nanu-c/zkgroup
+
+  - name: zkgroup-armhf
+    buildsystem: simple
+    only-arches:
+      - armhf
+    build-commands:
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_armhf.so ${FLATPAK_DEST}/usr/lib"
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/zkgroup
+        tag: main
+        dest: src/github.com/nanu-c/zkgroup
+
   - name: axolotl
     buildsystem: simple
     build-options:
@@ -51,7 +88,7 @@ modules:
       - "install -Dm 755 src/github.com/nanu-c/axolotl/axolotl ${FLATPAK_DEST}/bin/axolotl"
     sources:
       - type: git
-        url: "https://github.com/nanu-c/axolotl"
+        url: https://github.com/nanu-c/axolotl
         tag: main
         dest: src/github.com/nanu-c/axolotl
 
@@ -68,11 +105,11 @@ modules:
          npm run build"
       - "mkdir -p ${FLATPAK_DEST}/bin/axolotl-web"
       - "cp -r src/github.com/nanu-c/axolotl/axolotl-web/dist ${FLATPAK_DEST}/bin/axolotl-web"
-      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png"
+      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/usr/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png"
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/appdata/${FLATPAK_ID}.appdata.xml"
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/web/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
     sources:
       - type: git
-        url: "https://github.com/nanu-c/axolotl"
+        url: https://github.com/nanu-c/axolotl
         tag: main
         dest: src/github.com/nanu-c/axolotl

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -43,7 +43,7 @@ modules:
     only-arches:
       - x86_64
     build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_amd64.so ${FLATPAK_DEST}/usr/lib"
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_amd64.so ${FLATPAK_DEST}/lib"
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
@@ -55,7 +55,7 @@ modules:
     only-arches:
       - arm64
     build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_arm64.so ${FLATPAK_DEST}/usr/lib"
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_arm64.so ${FLATPAK_DEST}/lib"
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
@@ -67,7 +67,7 @@ modules:
     only-arches:
       - armhf
     build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_armhf.so ${FLATPAK_DEST}/usr/lib"
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_armhf.so ${FLATPAK_DEST}/lib"
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup


### PR DESCRIPTION
Add the required zkgroup library to the flatpak build in the same way which is done with the Snap package.

Use Electron v2 instead of v1 for the base
Disable separate locale config
Adjust icon location following flatpak changes