### PR TITLE
Use posix arch naming for Groupsv2 rust library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This is the Makefile for axolotl.
 # For more info about the syntax, see https://makefiletutorial.com/
 
-.PHONY: build clean build-axolotl-web build-axolotl install install-axolotl install-axolotl-web uninstall build-translation run check check-axolotl check-axolotl-web build-dependencies build-dependencies-axolotl-web build-dependencies-axolotl update-version build-zkgroup copy-zkgroup install-zkgroup install-clickable-zkgroup build-dependencies-flatpak build-dependencies-flatpak-web build-dependencies-flatpak-qt install-flatpak-web install-flatpak-qt build-snap install-snap check-platform-deb-arm64 dependencies-deb-arm64 build-deb-arm64 prebuild-package-deb-arm64 build-package-deb-arm64 install-deb-arm64 uninstall-deb-arm64 clean-deb-arm64 package-clean-deb-arm64
+.PHONY: build clean build-axolotl-web build-axolotl install install-axolotl install-axolotl-web uninstall build-translation run check check-axolotl check-axolotl-web build-dependencies build-dependencies-axolotl-web build-dependencies-axolotl update-version build-zkgroup copy-zkgroup install-zkgroup uninstall-zkgroup install-clickable-zkgroup uninstall-clickable-zkgroup build-dependencies-flatpak build-dependencies-flatpak-web build-dependencies-flatpak-qt install-flatpak-web install-flatpak-qt build-snap install-snap check-platform-deb-arm64 dependencies-deb-arm64 build-deb-arm64 prebuild-package-deb-arm64 build-package-deb-arm64 install-deb-arm64 uninstall-deb-arm64 clean-deb-arm64 package-clean-deb-arm64
 
 NPM_VERSION := $(shell npm --version 2>/dev/null)
 NODE_VERSION := $(shell node --version 2>/dev/null)
@@ -11,7 +11,7 @@ GIT_VERSION := $(shell git --version 2>/dev/null)
 AXOLOTL_GIT_VERSION := $(shell git tag | tail --lines=1)
 AXOLOTL_VERSION := $(subst v,,$(AXOLOTL_GIT_VERSION))
 UNAME_S := $(shell uname -s)
-UNAME_HARDWARE_PLATTFORM := $(shell uname --hardware-platform)
+HARDWARE_PLATFORM := $(shell uname --machine)
 CURRENT_DIR = $(shell pwd)
 
 
@@ -106,48 +106,28 @@ ifeq ($(UNAME_S), Linux)
 	&& $(GIT) submodule update \
 	&& cd $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/zkgroup \
 	&& $(CARGO) build --release --verbose \
-	&& mv -f $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/zkgroup/target/release/libzkgroup.so $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_$(UNAME_HARDWARE_PLATTFORM).so
+	&& mv -f $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/zkgroup/target/release/libzkgroup.so $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_$(HARDWARE_PLATFORM).so
 else
-	@echo architecture not (yet) supported $(UNAME_HARDWARE_PLATTFORM)
+	@echo architecture not (yet) supported $(HARDWARE_PLATFORM)
 	exit 1
 endif
 
 copy-zkgroup:
-ifdef GO_VERSION
-	@echo "Found go with version $(GO_VERSION)"
-else
-	@echo go not found, please install go
-	exit 1
-endif
-ifeq ($(UNAME_S), Linux)
 	$(GO) get -d github.com/nanu-c/zkgroup
-	cp $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_$(UNAME_HARDWARE_PLATTFORM).so $(CURRENT_DIR)/
-else
-	@echo "platform not supported $(UNAME_S)"
-	exit 1
-endif
+	cp $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_$(HARDWARE_PLATFORM).so $(CURRENT_DIR)/
 
 install-zkgroup:
-ifeq ($(UNAME_S), Linux)
-ifeq ($(UNAME_HARDWARE_PLATTFORM), x86_64)
-	@echo "install libzkgroup to /usr/lib"
-	sudo cp $(CURRENT_DIR)/libzkgroup_linux_amd64.so /usr/lib/
-else ifeq ($(UNAME_HARDWARE_PLATTFORM), aarch64)
-	@echo "install libzkgroup to /usr/lib"
-	sudo cp $(CURRENT_DIR)/libzkgroup_linux_arm64.so  /usr/lib/
-else
-	@echo architecture not  supported $(UNAME_HARDWARE_PLATTFORM)
-	exit 1
-endif
-else
-	@echo "platform not supported $(UNAME_S)"
-	exit 1
-endif
+	sudo cp $(CURRENT_DIR)/libzkgroup_linux_$(HARDWARE_PLATFORM).so /usr/lib/
+
+uninstall-zkgroup:
+	sudo rm -f /usr/lib/libzkgroup_linux_$(HARDWARE_PLATFORM).so
 
 install-clickable-zkgroup:
-	rm $(CURRENT_DIR)/lib/*.so |true
 	$(GO) get -d github.com/nanu-c/zkgroup
-	cp $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_$(UNAME_HARDWARE_PLATTFORM).so $(CURRENT_DIR)/lib/
+	cp $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_$(HARDWARE_PLATFORM).so $(CURRENT_DIR)/lib/
+
+uninstall-clickable-zkgroup:
+	rm -f $(CURRENT_DIR)/lib/libzkgroup_linux_$(HARDWARE_PLATFORM).so
 
 ## Flatpak
 build-dependencies-flatpak:

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ check-axolotl:
 	$(GO) test -race ./...
 
 run: build
-		@echo "Found go with version $(GO_VERSION)"
-		LD_LIBRARY_PATH=$(PWD) $(GO)  run .
+	@echo "Found go with version $(GO_VERSION)"
+	LD_LIBRARY_PATH=$(PWD) $(GO)  run .
 
 build-dependencies: build-dependencies-axolotl-web build-dependencies-axolotl
 

--- a/clickable.json
+++ b/clickable.json
@@ -29,5 +29,5 @@
     "libzkgroup*.so",
     "\\$GITHUB_WORKSPACE"
   ],
-  "postbuild": "$ROOT/scripts/postbuild.sh $INSTALL_DIR; cp ${GOPATH}/src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_${ARCH}.so ${INSTALL_DIR}/lib/libzkgroup_linux_${ARCH}.so"
+  "postbuild": "$ROOT/scripts/postbuild.sh $INSTALL_DIR; cp ${GOPATH}/src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_$(uname --machine).so ${INSTALL_DIR}/lib/libzkgroup_linux_$(uname --machine).so"
 }

--- a/flatpak/qt/org.nanuc.Axolotl.yml
+++ b/flatpak/qt/org.nanuc.Axolotl.yml
@@ -38,40 +38,14 @@ finish-args:
   - --env=AXOLOTL_GUI_DIR=/app/share/axolotl/
 
 modules:
-  - name: zkgroup-x86_64
+  - name: zkgroup
     buildsystem: simple
-    only-arches:
-      - x86_64
     build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_amd64.so ${FLATPAK_DEST}/lib"
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_${FLATPAK_ARCH}.so ${FLATPAK_DEST}/lib"
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
-        tag: main
-        dest: src/github.com/nanu-c/zkgroup
-
-  - name: zkgroup-arm64
-    buildsystem: simple
-    only-arches:
-      - arm64
-    build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_arm64.so ${FLATPAK_DEST}/lib"
-    sources:
-      - type: git
-        url: https://github.com/nanu-c/zkgroup
-        tag: main
-        dest: src/github.com/nanu-c/zkgroup
-
-  - name: zkgroup-armhf
-    buildsystem: simple
-    only-arches:
-      - armhf
-    build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_armhf.so ${FLATPAK_DEST}/lib"
-    sources:
-      - type: git
-        url: https://github.com/nanu-c/zkgroup
-        tag: main
+        tag: rename-built-x86_64-library # should be changed to main
         dest: src/github.com/nanu-c/zkgroup
 
   - name: axolotl

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -38,40 +38,14 @@ finish-args:
   - --env=AXOLOTL_WEB_DIR=/app/bin/axolotl-web/dist
 
 modules:
-  - name: zkgroup-x86_64
+  - name: zkgroup
     buildsystem: simple
-    only-arches:
-      - x86_64
     build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_amd64.so ${FLATPAK_DEST}/lib"
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_${FLATPAK_ARCH}.so ${FLATPAK_DEST}/lib"
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
-        tag: main
-        dest: src/github.com/nanu-c/zkgroup
-
-  - name: zkgroup-arm64
-    buildsystem: simple
-    only-arches:
-      - arm64
-    build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_arm64.so ${FLATPAK_DEST}/lib"
-    sources:
-      - type: git
-        url: https://github.com/nanu-c/zkgroup
-        tag: main
-        dest: src/github.com/nanu-c/zkgroup
-
-  - name: zkgroup-armhf
-    buildsystem: simple
-    only-arches:
-      - armhf
-    build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_armhf.so ${FLATPAK_DEST}/lib"
-    sources:
-      - type: git
-        url: https://github.com/nanu-c/zkgroup
-        tag: main
+        tag: rename-built-x86_64-library # should be changed to main
         dest: src/github.com/nanu-c/zkgroup
 
   - name: axolotl


### PR DESCRIPTION
This MR builds upon the zkgroup MR [here](https://github.com/nanu-c/zkgroup/pull/4)

If we name the architecture used by the rust library according to posix, we can greatly simplify the Flatpak manifests.

This removes the Clickable-specific $ARCH usage for the clickable with `uname --machine` as well.

This MR also touches the Makefile:

* Switch to `uname --machine` for architecture detection
* Rename Makefile var `UNAME_HARDWARE_PLATTFORM` to `HARDWARE_PLATFORM`
* Unify `copy-zkgroup`: I see no need to check if go is installed, either the command works or an error message will be shown.
* Unify `install-zkgroup`: Simplify usage by using HARDWARE_PLATFORM variable
* Split up `install-clickable-zkgroup`: Separate install from uninstall