### PR TITLE
Device linking page

### DIFF
--- a/axolotl-web/src/pages/About.vue
+++ b/axolotl-web/src/pages/About.vue
@@ -41,9 +41,6 @@ import { mapState } from "vuex";
 export default {
   name: "About",
   components: {},
-  props: {
-    msg: String,
-  },
   data() {
     return {
       showConfirmationModal: false,

--- a/axolotl-web/src/pages/ChatList.vue
+++ b/axolotl-web/src/pages/ChatList.vue
@@ -106,12 +106,6 @@ export default {
   components: {
     WarningMessage,
   },
-  props: {
-    msg: {
-      type: String,
-      default: ""
-    },
-  },
   data() {
     return {
       editActive: false,

--- a/axolotl-web/src/pages/Contacts.vue
+++ b/axolotl-web/src/pages/Contacts.vue
@@ -117,9 +117,6 @@ export default {
     EditContactModal,
     StartChatModal,
   },
-  props: {
-    msg: String,
-  },
   data() {
     return {
       addContactModal: false,

--- a/axolotl-web/src/pages/DeviceList.vue
+++ b/axolotl-web/src/pages/DeviceList.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="deviceList">
+    <!-- The first device is the main device and should not be shown -->
     <div v-if="devices && devices.length > 1">
       <div v-for="device in devices" :key="device.id" class="row device">
         <div v-if="device.id != 0" class="col-10">

--- a/axolotl-web/src/pages/DeviceList.vue
+++ b/axolotl-web/src/pages/DeviceList.vue
@@ -1,20 +1,14 @@
 <template>
   <div class="deviceList">
-    <!-- eslint-disable vue/no-use-v-if-with-v-for,vue/no-confusing-v-for-v-if -->
-    <div v-if="devices && devices.length>1">
-      <div
-        class="row device"
-        v-for="device in devices"
-        v-if="device.id != 1 && false"
-        v-bind:key="device.id"
-      >
-        <div class="col-10">
+    <div v-if="devices && devices.length > 1">
+      <div v-for="device in devices" :key="device.id" class="row device">
+        <div v-if="device.id != 0" class="col-10">
           <div class="device-name">{{ device.name }}</div>
           <div class="meta">
-            <span class="lastSeen"
-              ><span v-translate>Last seen:</span>
-              {{ humanifyDate(device.lastSeen) }}</span
-            >
+            <span class="lastSeen">
+              <span v-translate>Last seen:</span>
+              {{ humanifyDate(device.lastSeen) }}
+            </span>
           </div>
         </div>
         <div class="col-2 actions">
@@ -24,12 +18,10 @@
         </div>
       </div>
     </div>
-    <div v-else class="no-entries" v-translate>
-      No linked devices
-    </div>
+    <div v-else v-translate class="no-entries">No linked devices</div>
     <!-- eslint-enable -->
 
-    <button @click="linkDevice" class="btn start-chat">
+    <button class="btn start-chat" @click="linkDevice">
       <font-awesome-icon icon="plus" />
     </button>
     <add-device-modal
@@ -47,9 +39,6 @@ export default {
   name: "DeviceList",
   components: {
     AddDeviceModal,
-  },
-  props: {
-    msg: String,
   },
   data() {
     return {
@@ -124,5 +113,6 @@ export default {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  max-width: 35ch;
 }
 </style>

--- a/axolotl-web/src/pages/EditGroup.vue
+++ b/axolotl-web/src/pages/EditGroup.vue
@@ -64,9 +64,6 @@ export default {
   components: {
     AddGroupMembersModal,
   },
-  props: {
-    msg: String,
-  },
   data() {
     return {
       newGroupName: null,

--- a/axolotl-web/src/pages/NewGroup.vue
+++ b/axolotl-web/src/pages/NewGroup.vue
@@ -54,9 +54,6 @@ export default {
   components: {
     AddGroupMembersModal,
   },
-  props: {
-    msg: String,
-  },
   data() {
     return {
       newGroupName: null,

--- a/axolotl-web/src/pages/Settings.vue
+++ b/axolotl-web/src/pages/Settings.vue
@@ -61,9 +61,6 @@ export default {
   components: {
     ConfirmationModal,
   },
-  props: {
-    msg: String,
-  },
   data() {
     return {
       showConfirmationModal: false,

--- a/axolotl-web/src/pages/Verification.vue
+++ b/axolotl-web/src/pages/Verification.vue
@@ -44,9 +44,6 @@ export default {
   components: {
     VerificationPinInput,
   },
-  props: {
-    msg: String,
-  },
   data() {
     return {
       code: "",


### PR DESCRIPTION
This solves the problem, that the + button on the device linking page disappears after a second. This only happens in a qtwebengine context. With vue3 v-if and v-for really shouldn't be used together.
It also solves more linter messages and I removed unused props. 