### PR TITLE
WIP: local Flatpak with Makefile integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,11 +124,11 @@ build-crayfish:
 
 install-crayfish:
 	@echo "Installing crayfish..."
-	@sudo install -D -m 755 $(CURRENT_DIR)/crayfish/target/release/crayfish $(DESTDIR)$(LIBRARY_PREFIX)/
+	@install -D -m 755 $(CURRENT_DIR)/crayfish/target/release/crayfish $(DESTDIR)$(LIBRARY_PREFIX)/
 
 uninstall-crayfish:
 	@echo "Uninstalling crayfish..."
-	sudo rm -f $(DESTDIR)$(LIBRARY_PREFIX)/crayfish
+	@rm -f $(DESTDIR)$(LIBRARY_PREFIX)/crayfish
 
 ## zkgroup
 build-zkgroup:

--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,11 @@ check-axolotl:
 
 install-axolotl: build-axolotl
 	@echo "Installing axolotl..."
-	@sudo install -D -m 755 $(CURRENT_DIR)/axolotl $(DESTDIR)$(INSTALL_PREFIX)/axolotl/axolotl
+	@install -D -m 755 $(CURRENT_DIR)/axolotl $(DESTDIR)$(INSTALL_PREFIX)/axolotl/axolotl
 
 uninstall-axolotl:
 	@echo "Uninstalling axolotl..."
-	@sudo rm -rf $(DESTDIR)$(INSTALL_PREFIX)/axolotl
+	@rm -rf $(DESTDIR)$(INSTALL_PREFIX)/axolotl
 
 # axolotl-web
 build-dependencies-axolotl-web:
@@ -84,12 +84,12 @@ check-axolotl-web:
 
 install-axolotl-web: build-axolotl-web
 	@echo "Installing axolotl-web..."
-	@sudo mkdir -p $(DESTDIR)$(INSTALL_PREFIX)/axolotl/axolotl-web/
-	@sudo cp -r $(CURRENT_DIR)/axolotl-web/dist $(DESTDIR)$(INSTALL_PREFIX)/axolotl/axolotl-web/dist
+	@mkdir -p $(DESTDIR)$(INSTALL_PREFIX)/axolotl/axolotl-web/
+	@cp -r $(CURRENT_DIR)/axolotl-web/dist $(DESTDIR)$(INSTALL_PREFIX)/axolotl/axolotl-web/dist
 
 uninstall-axolotl-web:
 	@echo "Uninstalling axolotl-web..."
-	sudo rm -rf $(DESTDIR)$(INSTALL_PREFIX)/axolotl/axolotl-web/dist
+	@rm -rf $(DESTDIR)$(INSTALL_PREFIX)/axolotl/axolotl-web/dist
 
 ## utilities
 build-translation:
@@ -151,10 +151,10 @@ copy-zkgroup:
 	cp $(GOPATH)/src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_$(HARDWARE_PLATFORM).so $(CURRENT_DIR)/
 
 install-zkgroup:
-	sudo cp $(CURRENT_DIR)/libzkgroup_linux_$(HARDWARE_PLATFORM).so $(DESTDIR)$(LIBRARY_PREFIX)/
+	@cp $(CURRENT_DIR)/libzkgroup_linux_$(HARDWARE_PLATFORM).so $(DESTDIR)$(LIBRARY_PREFIX)/
 
 uninstall-zkgroup:
-	sudo rm -f $(DESTDIR)$(LIBRARY_PREFIX)/libzkgroup_linux_$(HARDWARE_PLATFORM).so
+	@rm -f $(DESTDIR)$(LIBRARY_PREFIX)/libzkgroup_linux_$(HARDWARE_PLATFORM).so
 
 install-clickable-zkgroup:
 	$(GO) get -d github.com/nanu-c/zkgroup
@@ -167,6 +167,7 @@ uninstall-clickable-zkgroup:
 build-dependencies-flatpak:
 	$(FLATPAK) install org.freedesktop.Sdk.Extension.golang//20.08
 	$(FLATPAK) install org.freedesktop.Sdk.Extension.node14//20.08
+	$(FLATPAK) install org.freedesktop.Sdk.Extension.rust-stable//20.08
 
 build-dependencies-flatpak-web: build-dependencies-flatpak
 	$(FLATPAK) install org.freedesktop.Platform//20.08
@@ -178,11 +179,17 @@ build-dependencies-flatpak-qt: build-dependencies-flatpak
 	$(FLATPAK) install org.kde.Sdk//5.15
 	$(FLATPAK) install io.qt.qtwebengine.BaseApp//5.15
 
+build-flatpak-web:
+	$(FLATPAK_BUILDER) flatpak/build --force-clean flatpak/web/org.nanuc.Axolotl.yml
+
+build-flatpak-qt:
+	$(FLATPAK_BUILDER) flatpak/build --force-clean flatpak/qt/org.nanuc.Axolotl.yml
+
 install-flatpak-web:
-	$(FLATPAK_BUILDER) --user --install --force-clean build flatpak/web/org.nanuc.Axolotl.yml
+	$(FLATPAK_BUILDER) --user --install --force-clean flatpak/build flatpak/web/org.nanuc.Axolotl.yml
 
 install-flatpak-qt:
-	$(FLATPAK_BUILDER) --user --install --force-clean build flatpak/qt/org.nanuc.Axolotl.yml
+	$(FLATPAK_BUILDER) --user --install --force-clean flatpak/build flatpak/qt/org.nanuc.Axolotl.yml
 
 ## Snap
 build-snap:

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -55,7 +55,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
-        tag: main
+        tag: flatpak-with-makefile-integration # TODO: change this to main once branch is merged
         dest: src/github.com/nanu-c/axolotl
 
   - name: zkgroup
@@ -74,7 +74,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
-        tag: main
+        tag: flatpak-with-makefile-integration # TODO: change this to main once branch is merged
         dest: src/github.com/nanu-c/zkgroup
 
   - name: axolotl
@@ -93,7 +93,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
-        tag: main
+        tag: flatpak-with-makefile-integration # TODO: change this to main once branch is merged
         dest: src/github.com/nanu-c/axolotl
 
   - name: axolotl-web
@@ -112,7 +112,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
-        tag: main
+        tag: flatpak-with-makefile-integration # TODO: change this to main once branch is merged
         dest: src/github.com/nanu-c/axolotl
 
   - name: install

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -110,9 +110,9 @@ modules:
         LIBRARY_PREFIX: /lib
     build-commands:
       - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-crayfish
-      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-zkgroup
       - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-axolotl
       - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-axolotl-web
+      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/zkgroup/target/release/libzkgroup.so ${DESTDIR}${LIBRARY_PREFIX}/"
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/usr/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png"
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/appdata/${FLATPAK_ID}.appdata.xml"
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/web/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -74,7 +74,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
-        tag: flatpak-with-makefile-integration # TODO: change this to main once branch is merged
+        tag: main
         dest: src/github.com/nanu-c/zkgroup
 
   - name: axolotl

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -63,14 +63,12 @@ modules:
     build-options:
       env:
         CARGO_HOME: ${FLATPAK_BUILDER_BUILDDIR}/.cargo
-        DESTDIR: ${FLATPAK_DEST}
-        LIBRARY_PREFIX: /lib
       append-path: /usr/lib/sdk/rust-stable/bin
       build-args:
         - --share=network
     build-commands:
       - cargo build --manifest-path src/github.com/nanu-c/zkgroup/lib/zkgroup/Cargo.toml --release
-      - install -Dm 755 src/github.com/nanu-c/zkgroup/lib/zkgroup/target/release/libzkgroup.so ${DESTDIR}${LIBRARY_PREFIX}/
+      - install -Dm 755 src/github.com/nanu-c/zkgroup/lib/zkgroup/target/release/libzkgroup.so ${FLATPAK_DEST}/lib
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -44,11 +44,14 @@ modules:
     build-options:
       env:
         CARGO_HOME: ${FLATPAK_BUILDER_BUILDDIR}/.cargo
+        DESTDIR: ${FLATPAK_DEST}
+        LIBRARY_PREFIX: /lib
       append-path: /usr/lib/sdk/rust-stable/bin
       build-args:
         - --share=network
     build-commands:
       - make --directory=src/github.com/nanu-c/axolotl build-crayfish
+      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-crayfish
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
@@ -60,11 +63,14 @@ modules:
     build-options:
       env:
         CARGO_HOME: ${FLATPAK_BUILDER_BUILDDIR}/.cargo
+        DESTDIR: ${FLATPAK_DEST}
+        LIBRARY_PREFIX: /lib
       append-path: /usr/lib/sdk/rust-stable/bin
       build-args:
         - --share=network
     build-commands:
       - cargo build --manifest-path src/github.com/nanu-c/zkgroup/lib/zkgroup/Cargo.toml --release
+      - install -Dm 755 src/github.com/nanu-c/zkgroup/lib/zkgroup/target/release/libzkgroup.so ${DESTDIR}${LIBRARY_PREFIX}/
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
@@ -74,12 +80,16 @@ modules:
   - name: axolotl
     buildsystem: simple
     build-options:
+      env:
+        DESTDIR: ${FLATPAK_DEST}
+        INSTALL_PREFIX: /bin
       append-path: /usr/lib/sdk/golang/bin
       build-args:
         - --share=network
     build-commands:
       - make --directory=src/github.com/nanu-c/axolotl build-dependencies-axolotl
       - make --directory=src/github.com/nanu-c/axolotl build-axolotl
+      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-axolotl
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
@@ -89,12 +99,16 @@ modules:
   - name: axolotl-web
     buildsystem: simple
     build-options:
+      env:
+        DESTDIR: ${FLATPAK_DEST}
+        INSTALL_PREFIX: /bin
       append-path: /usr/lib/sdk/node14/bin
       build-args:
         - --share=network
     build-commands:
       - make --directory=src/github.com/nanu-c/axolotl build-dependencies-axolotl-web
       - make --directory=src/github.com/nanu-c/axolotl build-axolotl-web
+      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-axolotl-web
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
@@ -103,21 +117,12 @@ modules:
 
   - name: install
     buildsystem: simple
-    build-options:
-      env:
-        DESTDIR: ${FLATPAK_DEST}
-        INSTALL_PREFIX: /bin
-        LIBRARY_PREFIX: /lib
     build-commands:
-      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-crayfish
-      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-axolotl
-      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-axolotl-web
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/zkgroup/target/release/libzkgroup.so ${DESTDIR}${LIBRARY_PREFIX}/"
-      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/usr/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png"
-      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/appdata/${FLATPAK_ID}.appdata.xml"
-      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/web/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
+      - install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/usr/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
+      - install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/appdata/${FLATPAK_ID}.appdata.xml
+      - install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/web/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
-        tag: flatpak-with-makefile-integration # TODO: change this to main later
+        tag: flatpak-with-makefile-integration # TODO: change this to main once branch is merged
         dest: src/github.com/nanu-c/axolotl

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -39,7 +39,7 @@ finish-args:
   - --env=AXOLOTL_WEB_DIR=/app/bin/axolotl-web/dist
 
 modules:
-  - name: build-crayfish
+  - name: crayfish
     buildsystem: simple
     build-options:
       env:
@@ -55,7 +55,7 @@ modules:
         tag: main
         dest: src/github.com/nanu-c/axolotl
 
-  - name: build-zkgroup
+  - name: zkgroup
     buildsystem: simple
     build-options:
       env:
@@ -71,7 +71,7 @@ modules:
         tag: main
         dest: src/github.com/nanu-c/zkgroup
 
-  - name: build-axolotl
+  - name: axolotl
     buildsystem: simple
     build-options:
       append-path: /usr/lib/sdk/golang/bin
@@ -86,7 +86,7 @@ modules:
         tag: main
         dest: src/github.com/nanu-c/axolotl
 
-  - name: build-axolotl-web
+  - name: axolotl-web
     buildsystem: simple
     build-options:
       append-path: /usr/lib/sdk/node14/bin

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -6,6 +6,7 @@ sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
   - org.freedesktop.Sdk.Extension.node14
+  - org.freedesktop.Sdk.Extension.rust-stable
 command: axolotl
 base: org.electronjs.Electron2.BaseApp
 base-version: '20.08'
@@ -38,52 +39,85 @@ finish-args:
   - --env=AXOLOTL_WEB_DIR=/app/bin/axolotl-web/dist
 
 modules:
-  - name: zkgroup
-    buildsystem: simple
-    build-commands:
-      - "install -Dm 755 src/github.com/nanu-c/zkgroup/lib/libzkgroup_linux_${FLATPAK_ARCH}.so ${FLATPAK_DEST}/lib"
-    sources:
-      - type: git
-        url: https://github.com/nanu-c/zkgroup
-        tag: main
-        dest: src/github.com/nanu-c/zkgroup
-
-  - name: axolotl
+  - name: build-crayfish
     buildsystem: simple
     build-options:
-      prefix: /usr/lib/sdk/golang
-      prepend-path: /usr/lib/sdk/golang/bin
+      env:
+        CARGO_HOME: ${FLATPAK_BUILDER_BUILDDIR}/.cargo
+      append-path: /usr/lib/sdk/rust-stable/bin
       build-args:
         - --share=network
     build-commands:
-      - "cd src/github.com/nanu-c/axolotl;
-         go mod download -x;
-         go build -v"
-      - "install -Dm 755 src/github.com/nanu-c/axolotl/axolotl ${FLATPAK_DEST}/bin/axolotl"
+      - make --directory=src/github.com/nanu-c/axolotl build-crayfish
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
         tag: main
         dest: src/github.com/nanu-c/axolotl
 
-  - name: axolotl-web
+  - name: build-zkgroup
     buildsystem: simple
     build-options:
-      prefix: /usr/lib/sdk/node14
-      prepend-path: /usr/lib/sdk/node14/bin
+      env:
+        CARGO_HOME: ${FLATPAK_BUILDER_BUILDDIR}/.cargo
+      append-path: /usr/lib/sdk/rust-stable/bin
       build-args:
         - --share=network
     build-commands:
-      - "cd src/github.com/nanu-c/axolotl/axolotl-web;
-         npm ci;
-         npm run build"
-      - "mkdir -p ${FLATPAK_DEST}/bin/axolotl-web"
-      - "cp -r src/github.com/nanu-c/axolotl/axolotl-web/dist ${FLATPAK_DEST}/bin/axolotl-web"
+      - cargo build --manifest-path src/github.com/nanu-c/zkgroup/lib/zkgroup/Cargo.toml --release
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/zkgroup
+        tag: main
+        dest: src/github.com/nanu-c/zkgroup
+
+  - name: build-axolotl
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/golang/bin
+      build-args:
+        - --share=network
+    build-commands:
+      - make --directory=src/github.com/nanu-c/axolotl build-dependencies-axolotl
+      - make --directory=src/github.com/nanu-c/axolotl build-axolotl
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/axolotl
+        tag: main
+        dest: src/github.com/nanu-c/axolotl
+
+  - name: build-axolotl-web
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/node14/bin
+      build-args:
+        - --share=network
+    build-commands:
+      - make --directory=src/github.com/nanu-c/axolotl build-dependencies-axolotl-web
+      - make --directory=src/github.com/nanu-c/axolotl build-axolotl-web
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/axolotl
+        tag: main
+        dest: src/github.com/nanu-c/axolotl
+
+  - name: install
+    buildsystem: simple
+    build-options:
+      env:
+        DESTDIR: ${FLATPAK_DEST}
+        INSTALL_PREFIX: /bin
+        LIBRARY_PREFIX: /lib
+    build-commands:
+      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-crayfish
+      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-zkgroup
+      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-axolotl
+      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-axolotl-web
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/usr/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png"
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/appdata/${FLATPAK_ID}.appdata.xml"
       - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/web/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
-        tag: main
+        tag: flatpak-with-makefile-integration # TODO: change this to main later
         dest: src/github.com/nanu-c/axolotl


### PR DESCRIPTION
Use the Makefile for a local flatpak build, using the targets already defined.

The flatpak-builder doesnt have `sudo`, and as such that has to be added manually when running the targets if required.

This also adds the `crayfish` library to the Flatpak.

Additionally, the zkgroup is built within the flatpak as to avoid the complex arch copy operation, and align with the other modules. 