### PR TITLE
Add new Crayfish Repo Info in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ build-deb-arm64: dependencies-deb-arm64
 	@cp --recursive $(CURRENT_DIR)/axolotl-web/dist $(CURRENT_DIR)/build/linux-arm64/axolotl-web/
 	@cp --recursive $(CURRENT_DIR)/guis $(CURRENT_DIR)/build/linux-arm64/
 	@echo "Building (rust)..."
-	@cd $(CURRENT_DIR) && git clone --depth=1 https://github.com/nanu-c/crayfish
+	@cd $(CURRENT_DIR) && git submodule init && git submodule update
 	@cd $(CURRENT_DIR)/crayfish && cargo build --release
 	@echo "Building complete."
 

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ build-deb-arm64: dependencies-deb-arm64
 	@cp --recursive $(CURRENT_DIR)/axolotl-web/dist $(CURRENT_DIR)/build/linux-arm64/axolotl-web/
 	@cp --recursive $(CURRENT_DIR)/guis $(CURRENT_DIR)/build/linux-arm64/
 	@echo "Building (rust)..."
+	@cd $(CURRENT_DIR) && git clone --depth=1 https://github.com/nanu-c/crayfish
 	@cd $(CURRENT_DIR)/crayfish && cargo build --release
 	@echo "Building complete."
 


### PR DESCRIPTION
The added line downloads the crayfish repo into the current folder and the rust building can then proceed as before - "go get" is not able to fetch git submodules, so this has to be done manually.