### PR TITLE
version change v1.0.8

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -18,7 +18,7 @@ import (
 
 const AppName = "textsecure.nanuc"
 
-const AppVersion = "1.0.7"
+const AppVersion = "1.0.8"
 
 // Do not allow sending attachments larger than 100M for now
 var MaxAttachmentSize int64 = 100 * 1024 * 1024

--- a/appimage/AppDir/axolotl.appdata.xml
+++ b/appimage/AppDir/axolotl.appdata.xml
@@ -29,6 +29,9 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="1.0.8" date="2021-11-21">
+            <url>https://github.com/nanu-c/axolotl/releases/tag/v1.0.8</url>
+        </release>
         <release version="1.0.7" date="2021-10-28">
             <url>https://github.com/nanu-c/axolotl/releases/tag/v1.0.7</url>
         </release>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.0.8 (Nov 21 2021) 
+------------------------------------
+* Support receiving unidentfied sender messages -> fixes receiving messages (nanu-c)
+* French translation updated (Anne017)
+* Delete warning message (nuehm-arno)
+* Standardise gettext usage (olof-nord)
+* Update electron (nanu-c)
+* Cross-compile capabilites in the makefile (nanu-c)
+* Debian packaging improvements (nuehm-arno)
+
 1.0.7 (Okt 28 2021) 
 ------------------------------------
 * Fix deleting chats (nuehm-arno)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -128,7 +128,7 @@ To build the application, use the following command from the root of this reposi
 
 To install the built snap, use snap:
 
-`sudo snap install axolotl_1.0.5_amd64.snap --dangerous`
+`sudo snap install axolotl_1.0.8_amd64.snap --dangerous`
 
 **Run**
 

--- a/flatpak/org.nanuc.Axolotl.appdata.xml
+++ b/flatpak/org.nanuc.Axolotl.appdata.xml
@@ -29,6 +29,9 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="1.0.8" date="2021-11-21">
+            <url>https://github.com/nanu-c/axolotl/releases/tag/v1.0.8</url>
+        </release>
         <release version="1.0.7" date="2021-10-28">
             <url>https://github.com/nanu-c/axolotl/releases/tag/v1.0.7</url>
         </release>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "textsecure.nanuc",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "A Signal compatible messaging client for Ubuntu phones",
     "title": "Axolotl",
     "architecture": "@CLICK_ARCH@",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ grade: stable
 confinement: strict
 base: core20
 icon: snap/gui/axolotl.png
-version: "1.0.7"
+version: "1.0.8"
 architectures:
   - build-on: amd64
   - build-on: arm64


### PR DESCRIPTION
1.0.8 (Nov 21 2021) 
------------------------------------
* Support receiving unidentfied sender messages -> fixes receiving messages (nanu-c)
* French translation updated (Anne017)
* Delete warning message (nuehm-arno)
* Standardise gettext usage (olof-nord)
* Update electron (nanu-c)
* Cross-compile capabilites in the makefile (nanu-c)
* Debian packaging improvements (nuehm-arno)