### PR TITLE
Remove unnecessary crayfish build dependency

### DIFF
--- a/clickable.yaml
+++ b/clickable.yaml
@@ -27,9 +27,6 @@ libraries:
     builder: rust
     src_dir: crayfish
     rust_channel: 1.55.0
-    # docker_image: rust
-    dependencies_host:
-      - crossbuild-essential-${ARCH}
   axolotlweb:
     image_setup:
       run:


### PR DESCRIPTION
The `crossbuild-essential-${ARCH}` is preinstalled in the Clickable docker images, so no need to add them here.