### PR TITLE
Fix #548 use UUID to fetch remote identityKey

### DIFF
--- a/app/webserver/webserver.go
+++ b/app/webserver/webserver.go
@@ -416,7 +416,7 @@ func wsReader(conn *websocket.Conn) {
 			if err != nil {
 				ShowError(err.Error())
 			}
-			fingerprintNumbers, fingerprintQRCode, err := textsecure.GetFingerprint(s.Tel)
+			fingerprintNumbers, fingerprintQRCode, err := textsecure.GetFingerprint(s.UUID, s.Tel)
 			if err != nil {
 				log.Debugln("[axolotl] identity information ", err)
 			}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,8 @@
-1.0.8 (Nov 21 2021) 
+prerelease :
+------------------------------------
+* Fix 'Verifiy Identity' (blackoverflow)
+
+1.0.8 (Nov 21 2021)
 ------------------------------------
 * Support receiving unidentfied sender messages -> fixes receiving messages (nanu-c)
 * French translation updated (Anne017)
@@ -8,7 +12,7 @@
 * Cross-compile capabilites in the makefile (nanu-c)
 * Debian packaging improvements (nuehm-arno)
 
-1.0.7 (Okt 28 2021) 
+1.0.7 (Okt 28 2021)
 ------------------------------------
 * Fix deleting chats (nuehm-arno)
 * Update electron version (Ferenc-)
@@ -16,7 +20,7 @@
 * Fix clickable zkgroup copy error (nanu-c)
 * Explicitly set clickable-rust-version (jonnius)
 
-1.0.6 (Okt 26 2021) 
+1.0.6 (Okt 26 2021)
 ------------------------------------
 * Fix signal desktop linking by change signal desktop link url (nanu-c)
 * Add FormFactor settings to desktop files (ferenc)
@@ -32,7 +36,7 @@
 
 A warm welcome to our new first time contributors: axiomista, kpenfound, ferenc
 
-1.0.5 (Sep 23 2021) 
+1.0.5 (Sep 23 2021)
 ------------------------------------
 * Fix registration by adding a new backend and use the signal upstream libraries for that ♡ ♥ ❤ 💓 💔 (jonnius, Johannes Renkl, nanu-c)
 * Basic editing contacts support, (could be improved) (nanu-c)
@@ -47,7 +51,7 @@ A warm welcome to our new first time contributors: axiomista, kpenfound, ferenc
 ------------------------------------
 * Add support for unidentified sender, fixes sending messages partly (nanu-c)
 * Better group error handling (nanu-c)
-* Makefile + Debian packaging improvements (nuehm-arno) 
+* Makefile + Debian packaging improvements (nuehm-arno)
 
 1.0.2 (Aug 23 2021)
 ------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/nanu-c/axolotl
 
 go 1.16
 
+replace github.com/signal-golang/textsecure => github.com/blackoverflow/textsecure v1.4.3-0.20211203185727-090c2e0a6c12
+
 require (
 	github.com/asticode/go-astikit v0.22.0 // indirect
 	github.com/asticode/go-astilectron v0.25.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/nanu-c/axolotl
 
 go 1.16
 
-replace github.com/signal-golang/textsecure => github.com/blackoverflow/textsecure v1.4.3-0.20211203185727-090c2e0a6c12
-
 require (
 	github.com/asticode/go-astikit v0.22.0 // indirect
 	github.com/asticode/go-astilectron v0.25.0
@@ -18,7 +16,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.0 // indirect
 	github.com/mutecomm/go-sqlcipher v0.0.0-20190227152316-55dbde17881f
 	github.com/pkg/errors v0.9.1
-	github.com/signal-golang/textsecure v1.4.2
+	github.com/signal-golang/textsecure v1.4.3
 	github.com/sirupsen/logrus v1.8.1
 	github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 // indirect
 	github.com/ttacon/libphonenumber v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/asticode/go-astikit v0.22.0 h1:ZI/gS/0bWlqPvC8KGuoOOl71ZjFtA4ypxYXxwW
 github.com/asticode/go-astikit v0.22.0/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
 github.com/asticode/go-astilectron v0.25.0 h1:eMDoHuEMn1uaLnRIIYLjhmqJUReifxyX6YyFSWmNtAA=
 github.com/asticode/go-astilectron v0.25.0/go.mod h1:Tx+aS0IvbV0cO4TlQbOO1NFA/lATj11vEStydyIjMjM=
+github.com/blackoverflow/textsecure v1.4.3-0.20211203185727-090c2e0a6c12 h1:FKrhUEsF+uFvmqDAfifPCSVqL8ROP0xs3MCL7j4GjKA=
+github.com/blackoverflow/textsecure v1.4.3-0.20211203185727-090c2e0a6c12/go.mod h1:WQU1duk8Ef6AARPSnf3nkAx8nsLFv/3O4mMu+YEnOpM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/asticode/go-astikit v0.22.0 h1:ZI/gS/0bWlqPvC8KGuoOOl71ZjFtA4ypxYXxwW
 github.com/asticode/go-astikit v0.22.0/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
 github.com/asticode/go-astilectron v0.25.0 h1:eMDoHuEMn1uaLnRIIYLjhmqJUReifxyX6YyFSWmNtAA=
 github.com/asticode/go-astilectron v0.25.0/go.mod h1:Tx+aS0IvbV0cO4TlQbOO1NFA/lATj11vEStydyIjMjM=
-github.com/blackoverflow/textsecure v1.4.3-0.20211203185727-090c2e0a6c12 h1:FKrhUEsF+uFvmqDAfifPCSVqL8ROP0xs3MCL7j4GjKA=
-github.com/blackoverflow/textsecure v1.4.3-0.20211203185727-090c2e0a6c12/go.mod h1:WQU1duk8Ef6AARPSnf3nkAx8nsLFv/3O4mMu+YEnOpM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -120,6 +118,8 @@ github.com/signal-golang/mimemagic v0.0.0-20200821045537-3f613cf2cd3f h1:S17lCk5
 github.com/signal-golang/mimemagic v0.0.0-20200821045537-3f613cf2cd3f/go.mod h1:tU6SWwv50oGkZNPlvTFvmqZvEBp0vWWCC+LCEVlTE5A=
 github.com/signal-golang/textsecure v1.4.2 h1:LipB2q/64BuYI8v/sJC/92crDFieM8H+ZOzyOXEtBFY=
 github.com/signal-golang/textsecure v1.4.2/go.mod h1:WQU1duk8Ef6AARPSnf3nkAx8nsLFv/3O4mMu+YEnOpM=
+github.com/signal-golang/textsecure v1.4.3 h1:AwGZJxDsyE4vZRlwgtlmTLMmUCbf8BTGM2IfhPMXP+o=
+github.com/signal-golang/textsecure v1.4.3/go.mod h1:WQU1duk8Ef6AARPSnf3nkAx8nsLFv/3O4mMu+YEnOpM=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=


### PR DESCRIPTION
Identity Keys of new contacts are referenced by UUID.

Assuming that all Identity Keys can be referenced by UUID, I changed the code to use the UUID instead of the Tel.
This should fix #548

Since this needs also changes in textsecure, I updated the dependency to v1.4.3.