### PR TITLE
Fix warnings abount FontAwesome in tests

### DIFF
--- a/axolotl-web/tests/unit/components/Message.spec.js
+++ b/axolotl-web/tests/unit/components/Message.spec.js
@@ -18,6 +18,7 @@ config.global = {
       }
     }
   ],
+  stubs: ['FontAwesomeIcon'],
 }
 
 describe('Message.vue', () => {


### PR DESCRIPTION
There are warnings about <font-awesome-icon> not being resolvable.
This PR fixes those warnings.