### PR TITLE
support older browsers qtwebengineview 5.12

### DIFF
--- a/axolotl-web/src/components/Message.vue
+++ b/axolotl-web/src/components/Message.vue
@@ -238,7 +238,7 @@ export default {
   mounted() {
     if (this.message.Attachment !== "" && this.message.Attachment !== null) {
       const attachment = JSON.parse(this.message.Attachment);
-      if (attachment?.length>0 && attachment[0].CType === 3) {
+      if (attachment&&attachment.length>0 && attachment[0].CType === 3) {
         this.audio = new Audio("http://localhost:9080/attachments?file=" + attachment[0].File);
         var that = this;
         this.audio.onloadedmetadata = function(){
@@ -349,8 +349,10 @@ export default {
       this.isPlaying = true;
     },
     pause(){
-      this.audio?.pause();
-      this.isPlaying = false;
+      if(this.audio && this.audio.currentTime>0){
+        this.audio.pause();
+        this.isPlaying = false;
+      }
 
     }
   },

--- a/axolotl-web/src/pages/MessageList.vue
+++ b/axolotl-web/src/pages/MessageList.vue
@@ -337,7 +337,9 @@ export default {
       if (
         !this.$data.scrollLocked &&
         event.target.scrollTop < 80 &&
-        this.$store.state.messageList?.Messages?.length > 19
+        this.$store.state.messageList &&
+        this.$store.state.messageList.Messages &&
+        this.$store.state.messageList.Messages.length > 19
       ) {
         this.$data.scrollLocked = true;
         this.$store.dispatch("getMoreMessages");


### PR DESCRIPTION
the syntax `object?.key` isn't supported by the html render engine in qtwebengineview 5.12. It fails with  `Uncaught SyntaxError: Unexpected token '.' `