### PR TITLE
WIP: Fix JoinGroup edge case

### DIFF
--- a/app/webserver/helpers.go
+++ b/app/webserver/helpers.go
@@ -239,14 +239,7 @@ func updateGroup(updateGroupData UpdateGroupMessage) *store.Session {
 func joinGroup(joinGroupmessage JoinGroupMessage) *store.Session {
 	log.Infoln("[axolotl] joinGroup", joinGroupmessage.ID)
 	group, err := textsecure.JoinGroup(joinGroupmessage.ID)
-	if err != nil {
-		// update group also in the case that the group is already joined to remove the join message
-		if group != nil {
-			session, _ := store.SessionsModel.GetByUUID(group.Hexid)
-			session.Name = group.DecryptedGroup.Title
-			session.GroupJoinStatus = group.JoinStatus
-			store.UpdateSession(session)
-		}
+	if err != nil && group == nil {// update group also in the case that the group is already joined to remove the join message
 		log.Errorln("[axolotl] joinGroup", err)
 		ShowError(err.Error())
 		return nil

--- a/app/webserver/helpers.go
+++ b/app/webserver/helpers.go
@@ -273,6 +273,7 @@ func joinGroup(joinGroupmessage JoinGroupMessage) *store.Session {
 		msg := session.Add("You accepted the invitation to the group.", "", []store.Attachment{}, "", true, store.ActiveSessionID)
 		msg.Flags = helpers.MsgFlagGroupJoined
 		store.SaveMessage(msg)
+		MessageHandler(msg)
 	}
 	store.UpdateSession(session)
 	requestEnterChat(store.ActiveSessionID)


### PR DESCRIPTION
In case the user has joined the group with Signal Desktop already, Axolotl should treat joining just as normal.
Like this, the decision is persisted and the group is refreshed when "Join" is clicked.