### PR TITLE
Display a cross to close a fullscreen picture

### DIFF
--- a/axolotl-web/src/pages/MessageList.vue
+++ b/axolotl-web/src/pages/MessageList.vue
@@ -24,7 +24,7 @@
             class="btn btn-secondary close"
             @click="showFullscreenImgSrc = ''"
           >
-            X
+            <font-awesome-icon icon="times" />
           </button>
         </div>
         <div v-if="showFullscreenVideoSrc !== ''" class="fullscreenImage">
@@ -41,7 +41,7 @@
             class="btn btn-secondary close"
             @click="showFullscreenVideoSrc = ''"
           >
-            X
+            <font-awesome-icon icon="times" />
           </button>
           <button class="btn btn-secondary save" @click="saveVideo($event)">
             <font-awesome-icon icon="arrow-down" />
@@ -533,6 +533,7 @@ input:focus {
   top: 10px;
   padding: 10px;
   background-color: #ffffff;
+  color: black;
 }
 .fullscreenImage .save {
   position: absolute;


### PR DESCRIPTION
When viewing a picture in fullscreen mode the "close" button had no
cross sign.
The "X" char was there but in white on a white background, so it was not
visible.
Its color has been set to black and instead of a "X" char the "times"
Font Awesome icon has been used.

See: /nanu-c/axolotl#720