### PR TITLE
Fix an issue in reading voice notes

### DIFF
--- a/app/store/attachment.go
+++ b/app/store/attachment.go
@@ -8,6 +8,7 @@ import (
 	"mime"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/nanu-c/axolotl/app/config"
@@ -36,6 +37,7 @@ func SaveAttachment(a *textsecure.Attachment) (Attachment, error) {
 	// 	ext = strings.Replace(a.MimeType, "video/", ".", 1)
 	// }
 	fileName := a.FileName
+	fileName = strings.Replace(fileName, "/", "-", -1)
 	if fileName == "" {
 		fileName = helpers.RandomString(10)
 		extension, err := mime.ExtensionsByType(a.MimeType)

--- a/app/store/attachment.go
+++ b/app/store/attachment.go
@@ -37,7 +37,7 @@ func SaveAttachment(a *textsecure.Attachment) (Attachment, error) {
 	// 	ext = strings.Replace(a.MimeType, "video/", ".", 1)
 	// }
 	fileName := a.FileName
-	fileName = strings.Replace(fileName, "/", "-", -1)
+	fileName = strings.ReplaceAll(fileName, "/", "-")
 	if fileName == "" {
 		fileName = helpers.RandomString(10)
 		extension, err := mime.ExtensionsByType(a.MimeType)


### PR DESCRIPTION
In some situations, voice notes couldn't be read and their duration was
written as "0s".

The root cause was the attachment's filename. It contained
a date which may contain slash "/" characters.

The slashes in the filename are now replaced by dashes.

See: /nanu-c/axolotl#713