### PR TITLE
[axolotl-web] linter: Address warnings about event naming

### DIFF
--- a/axolotl-web/src/components/Message.vue
+++ b/axolotl-web/src/components/Message.vue
@@ -42,7 +42,7 @@
               <img
                 :src="'http://localhost:9080/attachments?file=' + m.File"
                 alt="Fullscreen image"
-                @click="$emit('showFullscreenImg', m.File)"
+                @click="$emit('show-fullscreen-img', m.File)"
               >
             </div>
             <div v-else-if="m.CType === 3" class="attachment-audio">
@@ -67,7 +67,7 @@
             <div
               v-else-if="m.CType === 5"
               class="attachment-video"
-              @click="$emit('showFullscreenVideo', m.File)"
+              @click="$emit('show-fullscreen-video', m.File)"
             >
               <video>
                 <source
@@ -89,7 +89,7 @@
               'http://localhost:9080/attachments?file=' + message.Attachment
             "
             alt="Fullscreen image"
-            @click="$emit('showFullscreenImg', message.Attachment)"
+            @click="$emit('show-fullscreen-img', message.Attachment)"
           >
         </div>
         <div v-else-if="message.CType === 3" class="attachment-audio">
@@ -116,7 +116,7 @@
         <div
           v-else-if="message.CType === 5"
           class="attachment-video"
-          @click="$emit('showFullscreenVideo', message.Attachment)"
+          @click="$emit('show-fullscreen-video', message.Attachment)"
         >
           <video>
             <source
@@ -214,7 +214,7 @@ export default {
       default: () => {}
     }
   },
-  emits: ["showFullscreenImg", "showFullscreenVideo"],
+  emits: ["show-fullscreen-img", "show-fullscreen-video"],
   data() {
     return {
       showDate: false,

--- a/axolotl-web/src/components/VerificationPinInput.vue
+++ b/axolotl-web/src/components/VerificationPinInput.vue
@@ -42,7 +42,7 @@ export default {
       default: false,
     },
   },
-  emits:['inputValue','enter','clearValue'],
+  emits:['input-value','enter','clearValue'],
 
   data() {
     return {
@@ -119,7 +119,7 @@ export default {
     },
     emitInput() {
       const result = this.arraySize.join("").slice(0, this.numberOfBoxes);
-      this.$emit("inputValue", result);
+      this.$emit("input-value", result);
     },
     handleKeyDown(event, index) {
       const key = this.sanitizeKeyData(event.key);

--- a/axolotl-web/src/pages/MessageList.vue
+++ b/axolotl-web/src/pages/MessageList.vue
@@ -53,8 +53,8 @@
           :message="message"
           :is-group="isGroup"
           :names="names"
-          @showFullscreenImg="showFullscreenImg($event)"
-          @showFullscreenVideo="showFullscreenVideo($event)"
+          @show-fullscreen-img="showFullscreenImg($event)"
+          @show-fullscreen-video="showFullscreenVideo($event)"
           @click="handleClick($event)"
         />
       </div>
@@ -66,7 +66,8 @@
     <div
       v-if="chat.IsGroup && chat.GroupJoinStatus !== 0"
       class="messageInputBoxDisabled w-100"
-    > <p v-translate>
+    >
+      <p v-translate>
         Join this group? They won’t know you’ve seen their messages until you accept.
       </p>
       <div v-translate class="btn btn-primary" @click="joinGroupAccept">Join</div>
@@ -120,7 +121,7 @@
           </button>
         </div>
       </div>
-      <audio 
+      <audio
         v-if="voiceNote.blobUrl!=''"
         id="voiceNote"
         controls

--- a/axolotl-web/src/pages/Verification.vue
+++ b/axolotl-web/src/pages/Verification.vue
@@ -12,7 +12,7 @@
       </button>
     </div>
     <div v-if="!requestPin" class="verify">
-      <VerificationPinInput class="codeInput" :number-of-boxes="6" @inputValue="updateCode($event)" />
+      <VerificationPinInput class="codeInput" :number-of-boxes="6" @input-value="updateCode($event)" />
       <button
         v-translate
         :disabled="inProgress"


### PR DESCRIPTION
The axolotl-web linter currently complains about some vue event naming.

It wants the names to be written with hyphenation, instead with camelCasing.

This PR just renames the events, nothing else.

https://eslint.vuejs.org/rules/v-on-event-hyphenation.html