### PR TITLE
[axolotl-web]: Increment minimum Node.js version required

### DIFF
--- a/axolotl-web/package-lock.json
+++ b/axolotl-web/package-lock.json
@@ -51,7 +51,7 @@
         "sass-loader": "^12.4.0"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/axolotl-web/package.json
+++ b/axolotl-web/package.json
@@ -78,7 +78,7 @@
     "url": "https://github.com/nanu-c/axolotl/issues"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "homepage": "https://axolotl.chat",
   "keywords": [


### PR DESCRIPTION
With PR [692](https://github.com/nanu-c/axolotl/pull/692/), the local node.js version was incremented.

This PR follows up with this, and also adjusts the package.json engine version to v16.

With the CI already using Node.js v16, I believe this finishes the migration to v16.