### PR TITLE
Fix the unread counter

### DIFF
--- a/app/store/session.go
+++ b/app/store/session.go
@@ -235,7 +235,7 @@ func (s *Session) Add(text string, source string, file []Attachment, mimetype st
 	s.CType = ctype
 	// Only increments the counter for incoming messages, and only if the
 	// user is not currently on the conversation
-	if !outgoing && s.ID != sessionID {
+	if !outgoing && s.ID != sessionID && text != "readReceiptMessage" && text != "deliveryReceiptMessage" {
 		s.Unread++
 	}
 	UpdateSession(s)

--- a/app/store/session.go
+++ b/app/store/session.go
@@ -233,8 +233,9 @@ func (s *Session) Add(text string, source string, file []Attachment, mimetype st
 	s.Last = text
 	s.Len++
 	s.CType = ctype
-	//FIXME not shure if it breaks unread message counter
-	if !outgoing {
+	// Only increments the counter for incoming messages, and only if the
+	// user is not currently on the conversation
+	if !outgoing && s.ID != sessionID {
 		s.Unread++
 	}
 	UpdateSession(s)


### PR DESCRIPTION
The two items in #741 have been fixed:  
1. The unread counter is not incremented for incoming messages if they are in the currently open chat.
2. It's neither incremented for read receipts and delivery receipts.