### PR TITLE
Suggestion: Trim axolotl startup log message

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func setup() {
 	helpers.SetupLogging()
 	config.SetupConfig()
 	log.SetLevel(log.DebugLevel)
-	log.Infoln("[axolotl] Starting Signal for Ubuntu version", config.AppVersion)
+	log.Infoln("[axolotl] Starting axolotl version", config.AppVersion)
 }
 func runBackend() {
 	go worker.RunBackend()


### PR DESCRIPTION
During startup, currently "[axolotl] Starting Signal for Ubuntu version 1.0.9" is written as the first log output.

As this message is shown on every startup, also on devices which runs neither Ubuntu nor Ubuntu Touch (like my system for example).

I would argue that the project has grown and matured, and to instead of explicitly mentioning Ubuntu the log message, slim down the message to focus on the state of the application itself, rather than the system it runs on (or not).

WDYT? @nanu-c 