### PR TITLE
Add instructions on how to configure cross-linker for crayfish

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -184,12 +184,12 @@ jobs:
           mv libzkgroup_linux_armv7_v0.8.8.so $GITHUB_WORKSPACE/lib/libzkgroup_linux_armv7.so
 
       - name: Build crayfish (armhf)
-        uses: docker://clickable/ci-16.04-armhf:7.0.1
+        uses: docker://clickable/ci-16.04-armhf:7.1.1
         with:
           args: clickable build -a armhf --verbose --libs crayfish
 
       - name: Build click (armhf)
-        uses: docker://clickable/ci-16.04-armhf:7.0.1
+        uses: docker://clickable/ci-16.04-armhf:7.1.1
         env:
           GOPATH: $GITHUB_WORKSPACE/go
         with:
@@ -230,12 +230,12 @@ jobs:
             mv libzkgroup_linux_aarch64_v0.8.8.so $GITHUB_WORKSPACE/lib/libzkgroup_linux_aarch64.so
 
       - name: Build crayfish (arm64)
-        uses: docker://clickable/ci-16.04-arm64:7.0.1
+        uses: docker://clickable/ci-16.04-arm64:7.1.1
         with:
           args: clickable build -a arm64 --verbose --libs crayfish
 
       - name: Build click (arm64)
-        uses: docker://clickable/ci-16.04-arm64:7.0.1
+        uses: docker://clickable/ci-16.04-arm64:7.1.1
         env:
           GOPATH: $GITHUB_WORKSPACE/go
         with:
@@ -276,12 +276,12 @@ jobs:
             mv libzkgroup_linux_x86_64-v0.8.8.so $GITHUB_WORKSPACE/lib/libzkgroup_linux_x86_64.so
 
       - name: Build crayfish (amd64)
-        uses: docker://clickable/ci-16.04-amd64:7.0.1
+        uses: docker://clickable/ci-16.04-amd64:7.1.1
         with:
           args: clickable build -a amd64 --verbose --libs crayfish
 
       - name: Build click (amd64)
-        uses: docker://clickable/ci-16.04-amd64:7.0.1
+        uses: docker://clickable/ci-16.04-amd64:7.1.1
         env:
           GOPATH: $GITHUB_WORKSPACE/go
         with:

--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -184,7 +184,7 @@ jobs:
           mv libzkgroup_linux_armv7_v0.8.8.so $GITHUB_WORKSPACE/lib/libzkgroup_linux_armv7.so
 
       - name: Build crayfish (armhf)
-        uses: docker://clickable/ci-16.04-armhf:7.1.1
+        uses: docker://clickable/ci-16.04-armhf:latest
         with:
           args: clickable build -a armhf --verbose --libs crayfish
 

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: '7.0.1'
+clickable_minimum_required: 7.1.1
 
 builder: go
 prebuild: 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -99,6 +99,13 @@ rustup target add aarch64-unknown-linux-gnu
 rustup target add armv7-unknown-linux-gnueabihf
 ```
 
+Configure cargo with the cross-linker. For gcc:
+
+```bash
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=armv7-unknown-linux-gnueabihf-gcc
+```
+
 To do a cross-compile build, use the following:
 
 ```bash


### PR DESCRIPTION
Once we update the crayfish submodule to something containing the change from nanu-c/crayfish#8, we need:
- at least Clickable 7.1.1 to ensure the cargo linker env var is set in the build container
- instructions for setting the cargo linker env var in the docs for use cases without clickable