### PR TITLE
Improve logging

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -78,7 +78,9 @@ func GetConfig() (*textsecureConfig.Config, error) {
 	Config.UserAgent = fmt.Sprintf("TextSecure %s for Ubuntu Phone", AppVersion)
 	Config.UnencryptedStorage = true
 
-	Config.LogLevel = "debug"
+	if Config.LogLevel == "" {
+		Config.LogLevel = "info"
+	}
 	Config.CrayfishSupport = true
 	Config.AlwaysTrustPeerID = true
 	rootCA := filepath.Join(ConfigDir, "rootCA.crt")
@@ -180,4 +182,25 @@ func Unregister() {
 		log.Error(err)
 	}
 	os.Exit(1)
+}
+func SetLogLevel(loglevel string) {
+	if loglevel == "debug" {
+		log.SetLevel(log.DebugLevel)
+	} else if loglevel == "info" {
+		log.SetLevel(log.InfoLevel)
+	} else if loglevel == "warn" {
+		log.SetLevel(log.WarnLevel)
+	} else if loglevel == "error" {
+		log.SetLevel(log.ErrorLevel)
+	} else if loglevel == "fatal" {
+		log.SetLevel(log.FatalLevel)
+	} else if loglevel == "panic" {
+		log.SetLevel(log.PanicLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+		loglevel = "info"
+	}
+	Config.LogLevel = loglevel
+	textsecure.WriteConfig(ConfigFile, Config)
+	textsecure.RefreshConfig()
 }

--- a/app/settings/settings.go
+++ b/app/settings/settings.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/nanu-c/axolotl/app/config"
 
-	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -33,12 +32,6 @@ func LoadSettings() (*Settings, error) {
 	err = yaml.Unmarshal(b, s)
 	if err != nil {
 		return s, err
-	}
-	test := &s.DebugLog
-	if test != nil {
-		if s.DebugLog == true {
-			log.SetLevel(log.DebugLevel)
-		}
 	}
 	SettingsModel = s
 

--- a/app/webserver/helpers.go
+++ b/app/webserver/helpers.go
@@ -421,6 +421,7 @@ func sendConfig() {
 		RegisteredNumber: config.Config.Tel,
 		Version:          config.AppVersion,
 		Gui:              config.Gui,
+		LogLevel:         config.Config.LogLevel,
 	}
 	*message, err = json.Marshal(configEnvelope)
 	if err != nil {

--- a/app/webserver/messages.go
+++ b/app/webserver/messages.go
@@ -54,6 +54,7 @@ type ConfigEnvelope struct {
 	Notifications    bool
 	Encryption       bool
 	Gui              string
+	LogLevel         string
 }
 type Message struct {
 	Type string                 `json:"request"`

--- a/app/webserver/messages.go
+++ b/app/webserver/messages.go
@@ -199,3 +199,7 @@ type SetDarkMode struct {
 	Type     string `json:"request"`
 	DarkMode bool   `json:"darkMode"`
 }
+type SetLogLevelMessage struct {
+	Type  string `json:"request"`
+	Level string `json:"level"`
+}

--- a/app/webserver/webserver.go
+++ b/app/webserver/webserver.go
@@ -393,6 +393,10 @@ func wsReader(conn *websocket.Conn) {
 			if err != nil {
 				ShowError(err.Error())
 			}
+		case "setLogLevel":
+			setLogLevelMessage := SetLogLevelMessage{}
+			json.Unmarshal([]byte(p), &setLogLevelMessage)
+			config.SetLogLevel(setLogLevelMessage.Level)
 		case "toggleNotifications":
 			toggleNotificationsMessage := toggleNotificationsMessage{}
 			json.Unmarshal([]byte(p), &toggleNotificationsMessage)

--- a/app/worker/textsecureapi.go
+++ b/app/worker/textsecureapi.go
@@ -28,7 +28,6 @@ type TextsecureAPI struct {
 	ActiveSessionID string
 	PhoneNumber     string
 	UUID            string
-	LogLevel        bool
 }
 
 var Api = &TextsecureAPI{}
@@ -69,24 +68,6 @@ func (Api *TextsecureAPI) AddContact(name, phone, uuid string) {
 		ui.ShowError(err)
 	}
 }
-func (Api *TextsecureAPI) SetLogLevel() {
-	// Api.LogLevel = !Api.LogLevel
-	if !Api.LogLevel {
-		config.Config.LogLevel = "debug"
-		log.SetLevel(log.DebugLevel)
-		settings.SettingsModel.DebugLog = true
-		log.Infof("Set LogLevel to debug")
-		Api.LogLevel = true
-	} else {
-		config.Config.LogLevel = "info"
-		log.SetLevel(log.InfoLevel)
-		settings.SettingsModel.DebugLog = false
-		log.Infof("Set LogLevel to info")
-		Api.LogLevel = false
-	}
-	Api.SaveSettings()
-	// textsecure.WriteConfig(config.ConfigFile, config.Config)
-}
 
 func RunBackend() {
 	log.Debugf("[axolotl] Run Backend")
@@ -110,7 +91,6 @@ func RunBackend() {
 	}
 	sessionStarted = false
 	Api = &TextsecureAPI{}
-	Api.LogLevel = settings.SettingsModel.DebugLog
 	client = &textsecure.Client{
 		GetConfig: config.GetConfig,
 		GetPhoneNumber: func() string {

--- a/axolotl-web/src/pages/Settings.vue
+++ b/axolotl-web/src/pages/Settings.vue
@@ -33,20 +33,20 @@
         Dark mode
       </label>
     </div>
-    <div class="row g-3 mt-2 align-items-center">
+    <div class="row g-3 mt-1 align-items-center">
       <div class="col-auto">
-        <label v-translate for="loglevel" class="col-form-label">
-          Loglevel:
-        </label>
-      </div>
-      <div class="col-auto">
-        <select class="form-select" aria-label="Loglevel select" @change="setLogLevel($event)">
+        <select v-model="loglevel" class="form-select" aria-label="Loglevel select" @change="setLogLevel($event)">
           <option v-translate value="info">Info</option>
           <option v-translate value="warn">Warnings</option>
           <option v-translate value="error">Errors</option>
           <option v-translate value="panic">No logs</option>
           <option v-translate value="debug">Debugging</option>
         </select>
+      </div>
+      <div class="col-auto">
+        <label v-translate for="loglevel" class="col-form-label">
+          Loglevel
+        </label>
       </div>
     </div>
     <confirmation-modal
@@ -83,12 +83,14 @@ export default {
     return {
       showConfirmationModal: false,
       darkMode: false,
+      loglevel: "info",
     };
   },
   computed: mapState(["config"]),
   mounted() {
     this.$store.dispatch("getConfig");
     this.darkMode = this.getCookie("darkMode") === "true";
+    this.loglevel = this.config.LogLevel;
   },
   methods: {
     unregister() {

--- a/axolotl-web/src/pages/Settings.vue
+++ b/axolotl-web/src/pages/Settings.vue
@@ -21,15 +21,33 @@
     >
       Unregister
     </button>
-    <div class="custom-control custom-switch darkmode-switch">
+    <div class="custom-control form-check custom-switch darkmode-switch g-2">
       <input
         id="darkmode-switch"
         v-model="darkMode"
         type="checkbox"
-        class="custom-control-input"
+        class="form-check-input"
         @change="toggleDarkMode()"
-      >
-      <label v-translate class="custom-control-label" for="darkmode-switch">Dark mode</label>
+      />
+      <label v-translate class="form-check-label" for="darkmode-switch">
+        Dark mode
+      </label>
+    </div>
+    <div class="row g-3 mt-2 align-items-center">
+      <div class="col-auto">
+        <label v-translate for="loglevel" class="col-form-label">
+          Loglevel:
+        </label>
+      </div>
+      <div class="col-auto">
+        <select class="form-select" aria-label="Loglevel select" @change="setLogLevel($event)">
+          <option v-translate value="info">Info</option>
+          <option v-translate value="warn">Warnings</option>
+          <option v-translate value="error">Errors</option>
+          <option v-translate value="panic">No logs</option>
+          <option v-translate value="debug">Debugging</option>
+        </select>
+      </div>
     </div>
     <confirmation-modal
       v-if="showConfirmationModal"
@@ -82,6 +100,9 @@ export default {
       if (this.getCookie("darkMode") === "false") c = true;
       else c = false;
       this.$store.dispatch("setDarkMode", c);
+    },
+    setLogLevel(e) {
+      this.$store.dispatch("setLogLevel", e.target.value);
     },
     getCookie(cname) {
       const name = cname + "=";

--- a/axolotl-web/src/store/store.js
+++ b/axolotl-web/src/store/store.js
@@ -475,15 +475,6 @@ export default createStore({
         app.config.globalProperties.$socket.send(JSON.stringify(message))
       }
     },
-    setLogLevel(state, level) {
-      if (this.state.socket.isConnected) {
-        const message = {
-          "request": "setLogLevel",
-          "level": level
-        }
-        app.config.globalProperties.$socket.send(JSON.stringify(message))
-      }
-    },
     resetEncryption() {
       if (this.state.socket.isConnected) {
         const message = {
@@ -763,6 +754,15 @@ export default createStore({
         app.config.globalProperties.$socket.send(JSON.stringify(message))
         this.commit("SET_CAPTCHA_TOKEN_SENT");
 
+      }
+    },
+    setLogLevel(state, level) {
+      if (this.state.socket.isConnected) {
+        const message = {
+          "request": "setLogLevel",
+          level
+        }
+        app.config.globalProperties.$socket.send(JSON.stringify(message))
       }
     },
     setCaptchaToken(state, token) {

--- a/axolotl-web/src/store/store.js
+++ b/axolotl-web/src/store/store.js
@@ -475,6 +475,15 @@ export default createStore({
         app.config.globalProperties.$socket.send(JSON.stringify(message))
       }
     },
+    setLogLevel(state, level) {
+      if (this.state.socket.isConnected) {
+        const message = {
+          "request": "setLogLevel",
+          "level": level
+        }
+        app.config.globalProperties.$socket.send(JSON.stringify(message))
+      }
+    },
     resetEncryption() {
       if (this.state.socket.isConnected) {
         const message = {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/signal-golang/go-vcard v0.1.2
 	github.com/signal-golang/libphonenumber v1.2.2-0.20220127214340-b765372d3707
-	github.com/signal-golang/textsecure v1.10.4-0.20220221223745-501a7914780a
+	github.com/signal-golang/textsecure v1.10.4-0.20220301204135-53684eb9c15b
 	github.com/sirupsen/logrus v1.8.1
 	github.com/ttacon/builder v0.0.0-20170518171403-c099f663e1c2 // indirect
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
@@ -28,3 +28,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
+
+replace github.com/signal-golang/textsecure v1.10.4-0.20220221223745-501a7914780a => /home/nanu/go/src/github.com/signal-golang/textsecure

--- a/go.mod
+++ b/go.mod
@@ -28,5 +28,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
-
-replace github.com/signal-golang/textsecure v1.10.4-0.20220221223745-501a7914780a => /home/nanu/go/src/github.com/signal-golang/textsecure

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/signal-golang/libphonenumber v1.2.2-0.20220127214340-b765372d3707 h1:
 github.com/signal-golang/libphonenumber v1.2.2-0.20220127214340-b765372d3707/go.mod h1:oW+JXk+4C0R5h8BQzfRA4k/vXuBfBcNSqKWjn7Dgncs=
 github.com/signal-golang/mimemagic v0.0.0-20200821045537-3f613cf2cd3f h1:S17lCk5rcobvgcaLf7XSAoLuNkRPgFyhvgRA9JwDzHc=
 github.com/signal-golang/mimemagic v0.0.0-20200821045537-3f613cf2cd3f/go.mod h1:tU6SWwv50oGkZNPlvTFvmqZvEBp0vWWCC+LCEVlTE5A=
-github.com/signal-golang/textsecure v1.10.4-0.20220221223745-501a7914780a h1:5jSf1dkRKtF3n6bKfj111sJQbtZfEuPNsZ0GAi4EvHo=
-github.com/signal-golang/textsecure v1.10.4-0.20220221223745-501a7914780a/go.mod h1:teNGhh4TcoKEfPta0A8JKq25zerVF+mh1ZYWAelVeGQ=
+github.com/signal-golang/textsecure v1.10.4-0.20220301204135-53684eb9c15b h1:mQuC/qdr91I+KTGdIt+TTbGJZSlz0kOPN71cfkY9sUs=
+github.com/signal-golang/textsecure v1.10.4-0.20220301204135-53684eb9c15b/go.mod h1:teNGhh4TcoKEfPta0A8JKq25zerVF+mh1ZYWAelVeGQ=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/nanu-c/axolotl/app/config"
-	"github.com/nanu-c/axolotl/app/helpers"
 	"github.com/nanu-c/axolotl/app/push"
 	"github.com/nanu-c/axolotl/app/ui"
 	"github.com/nanu-c/axolotl/app/webserver"
@@ -32,9 +31,7 @@ func init() {
 	flag.StringVar(&config.ElectronFlag, "electron-flag", "", "Specify electron flag. Use no-ozone to disable Ozone/Wayland platform")
 }
 func setup() {
-	helpers.SetupLogging()
 	config.SetupConfig()
-	log.SetLevel(log.DebugLevel)
 	log.Infoln("[axolotl] Starting axolotl version", config.AppVersion)
 }
 func runBackend() {


### PR DESCRIPTION
Currently we load the loglevel from the config.yml and then overwrite it with `debug`. The loglevel should be set by the `textsecure` backend. This pr 

- removes the loglevel from settings, because it's in the shared config file with the backend
- lets the loglevel set by textsecure when axolotl starts
- adds a select for setting the loglevel to the settings page of axolotl web
- every new installation has the loglevel set to `info` by default.