### PR TITLE
Don't increment unread counter for empty messages

### DIFF
--- a/app/store/session.go
+++ b/app/store/session.go
@@ -235,7 +235,7 @@ func (s *Session) Add(text string, source string, file []Attachment, mimetype st
 	s.CType = ctype
 	// Only increments the counter for incoming messages, and only if the
 	// user is not currently on the conversation
-	if !outgoing && s.ID != sessionID && text != "readReceiptMessage" && text != "deliveryReceiptMessage" {
+	if !outgoing && s.ID != sessionID && text != "" && text != "readReceiptMessage" && text != "deliveryReceiptMessage" {
 		s.Unread++
 	}
 	UpdateSession(s)


### PR DESCRIPTION
When the receiver receives a message, an empty message is returned
to the sender.

This message was not labeled as a deliveryReceipt nor a readReceipt so
it incremented the unread counter on the conversations list.

Now an empty message does not increment the unread counter anymore.