### PR TITLE
Flatpak: Introduce the subdir config for modules (QT/Web)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,26 +23,26 @@ define APPDATA_TEXT=
 endef
 export APPDATA_TEXT
 
-NPM=$(shell which npm)
-GO=$(shell which go)
-GIT=$(shell which git)
-CARGO=$(shell which cargo)
-FLATPAK=$(shell which flatpak)
-FLATPAK_BUILDER=$(shell which flatpak-builder)
-SNAPCRAFT=$(shell which snapcraft)
-SNAP=$(shell which snap)
-APT=$(shell which apt)
-WGET=$(shell which wget)
-RUST=$(shell which rustup)
-CROSS=$(shell which cross)
-DOCKER=$(shell which docker)
-ASTILECTRON_BUILDER=$(shell which astilectron-bundler)
+NPM := $(shell which npm 2>/dev/null)
+GO := $(shell which go 2>/dev/null)
+GIT := $(shell which git 2>/dev/null)
+CARGO := $(shell which cargo 2>/dev/null)
+FLATPAK := $(shell which flatpak 2>/dev/null)
+FLATPAK_BUILDER := $(shell which flatpak-builder 2>/dev/null)
+SNAPCRAFT := $(shell which snapcraft 2>/dev/null)
+SNAP := $(shell which snap 2>/dev/null)
+APT := $(shell which apt 2>/dev/null)
+WGET := $(shell which wget 2>/dev/null)
+RUST := $(shell which rustup 2>/dev/null)
+CROSS := $(shell which cross 2>/dev/null)
+DOCKER := $(shell which docker 2>/dev/null)
+ASTILECTRON_BUILDER := $(shell which astilectron-bundler 2>/dev/null)
 
-DESTDIR = /
-INSTALL_PREFIX = usr/bin
-LIBRARY_PREFIX = usr/lib
-SHARE_PREFIX = usr/share
-CARGO_PREFIX = ${HOME}/.cargo/bin
+DESTDIR := /
+INSTALL_PREFIX := usr/bin
+LIBRARY_PREFIX := usr/lib
+SHARE_PREFIX := usr/share
+CARGO_PREFIX := ${HOME}/.cargo/bin
 
 all: clean build
 
@@ -101,9 +101,9 @@ uninstall-axolotl-web:
 build-translation:
 	$(NPM) run translate --prefix axolotl-web
 
-run: build
+run:
 	@echo "Found go with version $(GO_VERSION)"
-	LD_LIBRARY_PATH=$(PWD) $(GO)  run .
+	LD_LIBRARY_PATH=$(PWD) $(GO) run .
 
 clean:
 	rm -f $(CURRENT_DIR)/axolotl
@@ -134,7 +134,7 @@ install-crayfish:
 
 uninstall-crayfish:
 	@echo "Uninstalling crayfish..."
-	@rm -f $(DESTDIR)$(LIBRARY_PREFIX)/crayfish
+	@rm -f $(DESTDIR)$(INSTALL_PREFIX)/crayfish
 
 ## zkgroup
 build-zkgroup:
@@ -198,10 +198,10 @@ build-dependencies-flatpak-qt: build-dependencies-flatpak
 	$(FLATPAK) install io.qt.qtwebengine.BaseApp//5.15-21.08
 
 build-flatpak-web:
-	$(FLATPAK_BUILDER) flatpak/build --verbose --force-clean flatpak/web/org.nanuc.Axolotl.yml
+	$(FLATPAK_BUILDER) flatpak/build --verbose --force-clean --ccache flatpak/web/org.nanuc.Axolotl.yml
 
 build-flatpak-qt:
-	$(FLATPAK_BUILDER) flatpak/build --verbose --force-clean flatpak/qt/org.nanuc.Axolotl.yml
+	$(FLATPAK_BUILDER) flatpak/build --verbose --force-clean --ccache flatpak/qt/org.nanuc.Axolotl.yml
 
 install-flatpak-web:
 	$(FLATPAK_BUILDER) --user --install --force-clean flatpak/build flatpak/web/org.nanuc.Axolotl.yml

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,15 @@
 NPM_VERSION := $(shell npm --version 2>/dev/null)
 NODE_VERSION := $(shell node --version 2>/dev/null)
 GO_VERSION := $(shell go version 2>/dev/null)
-GOOS=$(shell go env GOOS)
-GOARCH=$(shell go env GOARCH)
+GOOS := $(shell go env GOOS)
+GOARCH := $(shell go env GOARCH)
 CARGO_VERSION := $(shell cargo --version 2>/dev/null)
 GIT_VERSION := $(shell git --version 2>/dev/null)
 AXOLOTL_GIT_VERSION := $(shell git tag | tail --lines=1)
 AXOLOTL_VERSION := $(subst v,,$(AXOLOTL_GIT_VERSION))
 UNAME_S := $(shell uname -s)
 HARDWARE_PLATFORM := $(shell uname --machine)
-CURRENT_DIR = $(shell pwd)
+CURRENT_DIR := $(shell pwd)
 
 define APPDATA_TEXT=
 \\t\t\t<release version="$(NEW_VERSION)" date="$(shell date --rfc-3339='date')">\n\

--- a/bundler.json
+++ b/bundler.json
@@ -4,6 +4,5 @@
   "icon_path_linux": "axolotl-web/public/axolotl.png",
   "version_electron": "17.0.0",
   "version_astilectron":"0.51.0",
-  "output_path": "output",
   "resources_path": "axolotl-web/dist"
 }

--- a/flatpak/org.nanuc.Axolotl.appdata.xml
+++ b/flatpak/org.nanuc.Axolotl.appdata.xml
@@ -2,7 +2,7 @@
 
 <!-- https://docs.flatpak.org/en/latest/freedesktop-quick-reference.html#appdata-files -->
 
-<component type="desktop">
+<component type="desktop-application">
     <id>org.nanuc.Axolotl</id>
     <name>Axolotl</name>
     <summary>Axolotl is a crossplattform Signal client</summary>

--- a/flatpak/qt/org.nanuc.Axolotl.yml
+++ b/flatpak/qt/org.nanuc.Axolotl.yml
@@ -55,9 +55,10 @@ modules:
     build-options:
       build-args:
         - --share=network
+    subdir: src/github.com/nanu-c/axolotl
     build-commands:
-      - make --directory=src/github.com/nanu-c/axolotl build-crayfish
-      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-crayfish
+      - make build-crayfish
+      - make --environment-overrides install-crayfish
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
@@ -66,12 +67,9 @@ modules:
 
   - name: zkgroup
     buildsystem: simple
-    build-options:
-      build-args:
-        - --share=network
+    subdir: src/github.com/nanu-c/zkgroup/lib
     build-commands:
-      - cargo build --manifest-path src/github.com/nanu-c/zkgroup/lib/zkgroup/Cargo.toml --release
-      - install -Dm 755 src/github.com/nanu-c/zkgroup/lib/zkgroup/target/release/libzkgroup.so ${FLATPAK_DEST}/lib/libzkgroup_linux_${FLATPAK_ARCH}.so
+      - install -Dm 755 libzkgroup_linux_${FLATPAK_ARCH}.so ${FLATPAK_DEST}/lib/libzkgroup_linux_${FLATPAK_ARCH}.so
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
@@ -83,11 +81,11 @@ modules:
     build-options:
       build-args:
         - --share=network
+    subdir: src/github.com/nanu-c/axolotl
     build-commands:
-      - "cd src/github.com/nanu-c/axolotl;
-         go mod download -x;
+      - "go mod download -x;
          go build -v"
-      - "install -Dm 755 src/github.com/nanu-c/axolotl/axolotl ${FLATPAK_DEST}/bin/axolotl"
+      - "install -Dm 755 axolotl ${FLATPAK_DEST}/bin/axolotl"
       - "install -Dm 755 $(which qmlscene) ${FLATPAK_DEST}/bin"
     sources:
       - type: git
@@ -100,17 +98,28 @@ modules:
     build-options:
       build-args:
         - --share=network
+    subdir: src/github.com/nanu-c/axolotl
     build-commands:
-      - "cd src/github.com/nanu-c/axolotl/axolotl-web;
+      - "cd axolotl-web;
          npm ci;
          npm run build"
       - "mkdir -p ${FLATPAK_DEST}/bin/axolotl-web"
-      - "mkdir -p ${FLATPAK_DEST}/share/axolotl"
-      - "cp -r src/github.com/nanu-c/axolotl/axolotl-web/dist ${FLATPAK_DEST}/bin/axolotl-web"
-      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/usr/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png"
-      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/appdata/${FLATPAK_ID}.appdata.xml"
-      - "install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/qt/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
-      - "cp -r src/github.com/nanu-c/axolotl/guis ${FLATPAK_DEST}/share/axolotl/"
+      - "cp -r axolotl-web/dist ${FLATPAK_DEST}/bin/axolotl-web"
+    sources:
+      - type: git
+        url: https://github.com/nanu-c/axolotl
+        tag: main
+        dest: src/github.com/nanu-c/axolotl
+
+  - name: metadata
+    buildsystem: simple
+    subdir: src/github.com/nanu-c/axolotl
+    build-commands:
+      - install -Dm 644 flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
+      - install -Dm 644 flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - install -Dm 644 flatpak/qt/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - mkdir -p ${FLATPAK_DEST}/share/axolotl
+      - cp -r guis ${FLATPAK_DEST}/share/axolotl/
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -56,9 +56,10 @@ modules:
     build-options:
       build-args:
         - --share=network
+    subdir: src/github.com/nanu-c/axolotl
     build-commands:
-      - make --directory=src/github.com/nanu-c/axolotl build-crayfish
-      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-crayfish
+      - make build-crayfish
+      - make --environment-overrides install-crayfish
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
@@ -67,12 +68,9 @@ modules:
 
   - name: zkgroup
     buildsystem: simple
-    build-options:
-      build-args:
-        - --share=network
+    subdir: src/github.com/nanu-c/zkgroup/lib
     build-commands:
-      - cargo build --manifest-path src/github.com/nanu-c/zkgroup/lib/zkgroup/Cargo.toml --release
-      - install -Dm 755 src/github.com/nanu-c/zkgroup/lib/zkgroup/target/release/libzkgroup.so ${FLATPAK_DEST}/lib/libzkgroup_linux_${FLATPAK_ARCH}.so
+      - install -Dm 755 libzkgroup_linux_${FLATPAK_ARCH}.so ${FLATPAK_DEST}/lib/libzkgroup_linux_${FLATPAK_ARCH}.so
     sources:
       - type: git
         url: https://github.com/nanu-c/zkgroup
@@ -84,13 +82,14 @@ modules:
     build-options:
       build-args:
         - --share=network
+    subdir: src/github.com/nanu-c/axolotl
     build-commands:
-      - make --directory=src/github.com/nanu-c/axolotl build-dependencies-axolotl-web
-      - make --directory=src/github.com/nanu-c/axolotl build-axolotl-web
-      - make --directory=src/github.com/nanu-c/axolotl build-dependencies-axolotl
-      - make --directory=src/github.com/nanu-c/axolotl build-dependencies-axolotl-electron-bundle
-      - make --directory=src/github.com/nanu-c/axolotl build-axolotl-electron-bundle
-      - make --directory=src/github.com/nanu-c/axolotl --environment-overrides install-axolotl-electron-bundle
+      - make build-dependencies-axolotl-web
+      - make build-axolotl-web
+      - make build-dependencies-axolotl
+      - make build-dependencies-axolotl-electron-bundle
+      - make build-axolotl-electron-bundle
+      - make --environment-overrides install-axolotl-electron-bundle
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
@@ -99,17 +98,22 @@ modules:
 
   - name: metadata
     buildsystem: simple
+    subdir: src/github.com/nanu-c/axolotl
     build-commands:
-      - install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/usr/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
-      - install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/appdata/${FLATPAK_ID}.appdata.xml
-      - install -Dm 644 src/github.com/nanu-c/axolotl/flatpak/web/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
-      - install -Dm 755 run.sh ${FLATPAK_DEST}${INSTALL_PREFIX}/run.sh
+      - install -Dm 644 flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
+      - install -Dm 644 flatpak/org.nanuc.Axolotl.appdata.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - install -Dm 644 flatpak/web/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
     sources:
       - type: git
         url: https://github.com/nanu-c/axolotl
         tag: main
         dest: src/github.com/nanu-c/axolotl
-      # Wrapper to launch the app
+
+  - name: run
+    buildsystem: simple
+    build-commands:
+      - install -Dm 755 run.sh ${FLATPAK_DEST}/bin/run.sh
+    sources:
       - type: script
         dest-filename: run.sh
         commands:


### PR DESCRIPTION
This allows setting the subdirectory used for all build-commands instead of using the make `--directory` flag.

Makefile: use the simply expanded assignment (:=) for all variables as to allow command-line overrides.
Makefile: fix crayfish uninstall path.
Makefile: Try to silence Makefile not found errors when running in an environment which doesnt have all the binaries installed

Flatpak: Do not build zkgroup, but use already built files as a build fails on aarch64. (building from source for aarch64 will need further investigation)
Flatpak: Install app icon to correct folder

Electron Bundler: Remove output_path config, as this is the default value.

Flatpak AppData: Use the new type [1]

[1] https://github.com/flathub/flathub/wiki/AppData-Guidelines#header