### PR TITLE
support captchav2

### DIFF
--- a/guis/qml/qml/MainQML.qml
+++ b/guis/qml/qml/MainQML.qml
@@ -30,8 +30,40 @@ import QtMultimedia 5.8
       // interceptor to make the registration captcha work
       var msg = "[Axolotl Web View] [JS] url changed %1".arg(url)
       console.log(msg)
-      var  interceptor = "window.onToken = function(token){window.location = 'http://localhost:9080/?token='+token;};"
-      webView.runJavaScript(interceptor)
+      if (url == "https://signalcaptchas.org/registration/generate.html"){
+        var  interceptor = `
+        // override the default onload function
+				
+				window.onload=function() {
+					var action = 'registration';
+					var isDone = false;
+					var sitekey = '6LfBXs0bAAAAAAjkDyyI1Lk5gBAUWfhI_bIyox5W';
+			
+					var widgetId = grecaptcha.enterprise.render('container', {
+					sitekey: sitekey,
+					size: 'checkbox',
+					callback: function (token) {
+						isDone = true;
+						document.body.removeAttribute('class');
+						window.location = ['http://localhost:9080/?token=', sitekey, action, token].join(".");
+					},
+					});
+				}
+				// cleanup
+				var bodyTag = document.getElementsByTagName('body')[0];	
+				bodyTag.innerHTML ='<div id="container"></div>'
+				grecaptcha  = undefined
+
+				// reload recaptcha
+				var script = document.createElement('script');
+				script.type = 'text/javascript';
+				script.src = 'https://www.google.com/recaptcha/enterprise.js?onload=onload&render=explicit';
+				bodyTag.appendChild(script);
+				`
+        webView.runJavaScript(interceptor);
+        console.log("run interceptor")
+      }
+
     }
   WebEngineProfile{
     id:webProfile

--- a/guis/qml/ut/MainUt.qml
+++ b/guis/qml/ut/MainUt.qml
@@ -40,33 +40,34 @@ UITK.Page {
       if (url == "https://signalcaptchas.org/registration/generate.html"){
         console.log("[Axolotl Web View] [JS] run interceptor")
         var  interceptor = `
-              				// override the default onload function
+          // override the default onload function
 				
-				window.onload=function() {
-					var action = 'registration';
-					var isDone = false;
-					var sitekey = '6LfBXs0bAAAAAAjkDyyI1Lk5gBAUWfhI_bIyox5W';
-			
-					var widgetId = grecaptcha.enterprise.render('container', {
-					sitekey: sitekey,
-					size: 'checkbox',
-					callback: function (token) {
-						isDone = true;
-						document.body.removeAttribute('class');
-						window.location = ['http://localhost:9080/?token=signal-recaptcha-v2', sitekey, action, token].join(".");
-					},
-					});
-				}
-				// cleanup
-				var bodyTag = document.getElementsByTagName('body')[0];	
-				bodyTag.innerHTML ='<div id="container"></div>'
-				grecaptcha  = undefined
+          window.onload=function() {
+            var action = 'registration';
+            var isDone = false;
+            var sitekey = '6LfBXs0bAAAAAAjkDyyI1Lk5gBAUWfhI_bIyox5W';
+        
+            var widgetId = grecaptcha.enterprise.render('container', {
+            sitekey: sitekey,
+            size: 'checkbox',
+            callback: function (token) {
+              isDone = true;
+              document.body.removeAttribute('class');
+              window.location = ['http://localhost:9080/?token=signal-recaptcha-v2', sitekey, action, token].join(".");
+            },
+            });
+          }
+          // cleanup
+          var bodyTag = document.getElementsByTagName('body')[0];	
+          bodyTag.innerHTML ='<div id="container"></div>'
+          grecaptcha  = undefined
 
-				// reload recaptcha
-				var script = document.createElement('script');
-				script.type = 'text/javascript';
-				script.src = 'https://www.google.com/recaptcha/enterprise.js?onload=onload&render=explicit';
-				bodyTag.appendChild(script);
+          // reload recaptcha
+          var script = document.createElement('script');
+          script.type = 'text/javascript';
+          script.src = 'https://www.google.com/recaptcha/enterprise.js?onload=onload&render=explicit';
+          bodyTag.appendChild(script);
+        `
         _webView.runJavaScript(interceptor);
     
       }

--- a/guis/qml/ut/MainUt.qml
+++ b/guis/qml/ut/MainUt.qml
@@ -37,8 +37,39 @@ UITK.Page {
     onLoadingChanged: {
       var msg = "[Axolotl Web View] [JS] url changed %1".arg(url)
       console.log(msg)
-      var  interceptor = "window.onToken = function(token) {window.location = 'http://localhost:9080/?token='+token;};"
-      _webView.runJavaScript(interceptor)
+      if (url == "https://signalcaptchas.org/registration/generate.html"){
+        console.log("[Axolotl Web View] [JS] run interceptor")
+        var  interceptor = `
+              				// override the default onload function
+				
+				window.onload=function() {
+					var action = 'registration';
+					var isDone = false;
+					var sitekey = '6LfBXs0bAAAAAAjkDyyI1Lk5gBAUWfhI_bIyox5W';
+			
+					var widgetId = grecaptcha.enterprise.render('container', {
+					sitekey: sitekey,
+					size: 'checkbox',
+					callback: function (token) {
+						isDone = true;
+						document.body.removeAttribute('class');
+						window.location = ['http://localhost:9080/?token=signal-recaptcha-v2', sitekey, action, token].join(".");
+					},
+					});
+				}
+				// cleanup
+				var bodyTag = document.getElementsByTagName('body')[0];	
+				bodyTag.innerHTML ='<div id="container"></div>'
+				grecaptcha  = undefined
+
+				// reload recaptcha
+				var script = document.createElement('script');
+				script.type = 'text/javascript';
+				script.src = 'https://www.google.com/recaptcha/enterprise.js?onload=onload&render=explicit';
+				bodyTag.appendChild(script);
+        _webView.runJavaScript(interceptor);
+    
+      }
     }
     onJavaScriptDialogRequested: function(request) {
       request.accepted = true;

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func runElectron() {
 		return
 	})
 	w.On(astilectron.EventNameWindowEventDidGetRedirectRequest, func(e astilectron.Event) (deleteListener bool) {
-		log.Infof("[axolotl-electron] Electron redirect request ", e.URLNew)
+		log.Infoln("[axolotl-electron] Electron redirect request ", e.URLNew)
 		return
 	})
 	w.On(astilectron.EventNameWindowEventWebContentsExecutedJavaScript, func(e astilectron.Event) (deleteListener bool) {


### PR DESCRIPTION
Signal changed from reCaptcha to reCaptcha enterprise. They call it captchav2.

The token is generated and then it opens `signalcaptcha://` with the token. The problem is, we don't want to register an url handler for this, because then we compete with signal-desktop.
The call for opening the url is happening in an callback function of a callback function. So we have to reinitialize everything. 