### PR TITLE
CI: Specify flatpak-builder cache key

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -206,6 +206,7 @@ jobs:
         with:
           bundle: axolotl-web.flatpak
           manifest-path: flatpak/web/org.nanuc.Axolotl.yml
+          cache-key: flatpak-builder-web-${{ github.sha }}
 
   package-flatpak-qt:
     name: Package as Flatpak QT bundle
@@ -225,7 +226,7 @@ jobs:
         with:
           bundle: axolotl-qt.flatpak
           manifest-path: flatpak/qt/org.nanuc.Axolotl.yml
-
+          cache-key: flatpak-builder-qt-${{ github.sha }}
 
   package-deb-arm64:
     name: Package as Debian arm64


### PR DESCRIPTION
This as to avoid the Error: Failed to save cache: ReserveCacheError: Unable to reserve cache with key -x86_64, another job may be creating this cache.

 https://github.com/nanu-c/axolotl/runs/5785632562?check_suite_focus=true