### PR TITLE
remove window.onload alert

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,7 +181,6 @@ func runElectron() {
 				script.type = 'text/javascript';
 				script.src = "https://www.google.com/recaptcha/enterprise.js?onload=onload&render=explicit";
 				bodyTag.appendChild(script);
-				alert("overriding onload");
 				`)
 		}
 		return


### PR DESCRIPTION
Fixes https://github.com/nanu-c/axolotl/issues/798

Removes the alert from the electron captcha v2 loading