### PR TITLE
Update astilectron bundler

### DIFF
--- a/bundler.json
+++ b/bundler.json
@@ -3,6 +3,6 @@
   "icon_path_darwin": "axolotl-web/public/axolotl.png",
   "icon_path_linux": "axolotl-web/public/axolotl.png",
   "version_electron": "18.0.1",
-  "version_astilectron":"0.51.0",
+  "version_astilectron":"0.55.0",
   "resources_path": "axolotl-web/dist"
 }

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func runElectron() {
 		AppIconDarwinPath:  "axolotl-web/public/axolotl.png", // Same here
 		BaseDirectoryPath:  electronPath,
 		VersionElectron:    "18.0.1",
-		VersionAstilectron: "0.51.0",
+		VersionAstilectron: "0.55.0",
 		SingleInstance:     true,
 		ElectronSwitches:   electronSwitches,
 	}


### PR DESCRIPTION
While packaging v1.3.0 for a flatpak release, I noticed that there has been some new versions of released of the astilectron electron bundler.

As to keep up to date and allow using the latest and greatest, this PR updates the version to the latest release as of today, `0.55.0`.

https://github.com/asticode/astilectron/releases/tag/v0.55.0