### PR TITLE
fix flatpack building failing with git+ssh  links in package-lock.json 

### DIFF
--- a/axolotl-web/package-lock.json
+++ b/axolotl-web/package-lock.json
@@ -8172,7 +8172,7 @@
     },
     "node_modules/mic-recorder-to-mp3": {
       "version": "2.2.2",
-      "resolved": "git+ssh://git@github.com/NikolaBalaban/mic-recorder-to-mp3.git#b07b6408c41cb55122169739e4bdce626660c109",
+      "resolved": "git+https://github.com/NikolaBalaban/mic-recorder-to-mp3.git#b07b6408c41cb55122169739e4bdce626660c109",
       "license": "MIT",
       "dependencies": {
         "lamejs": "^1.2.0"
@@ -19170,7 +19170,7 @@
       "peer": true
     },
     "mic-recorder-to-mp3": {
-      "version": "git+ssh://git@github.com/NikolaBalaban/mic-recorder-to-mp3.git#b07b6408c41cb55122169739e4bdce626660c109",
+      "version": "git+https://github.com/NikolaBalaban/mic-recorder-to-mp3.git#b07b6408c41cb55122169739e4bdce626660c109",
       "from": "mic-recorder-to-mp3@git+https://github.com/NikolaBalaban/mic-recorder-to-mp3.git",
       "requires": {
         "lamejs": "^1.2.0"


### PR DESCRIPTION
`git+ssh://` isn't supported by the flatpack builder.
fixes #838 