### PR TITLE
[axolotl-web] Adjust format used for mic-recorder-to-mp3 git npm dependency

### DIFF
--- a/axolotl-web/package-lock.json
+++ b/axolotl-web/package-lock.json
@@ -17,7 +17,7 @@
         "file-saver": "^2.0.5",
         "linkify-html": "^3.0.4",
         "linkifyjs": "^3.0.4",
-        "mic-recorder-to-mp3": "git+https://github.com/NikolaBalaban/mic-recorder-to-mp3.git",
+        "mic-recorder-to-mp3": "https://git@github.com/NikolaBalaban/mic-recorder-to-mp3.git",
         "moment": "^2.29.4",
         "qrcode": "1.4.4 || ^1.5.1",
         "vue": "^3.2.37",
@@ -4431,8 +4431,7 @@
     },
     "node_modules/mic-recorder-to-mp3": {
       "version": "2.2.2",
-      "resolved": "git+ssh://git@github.com/NikolaBalaban/mic-recorder-to-mp3.git#b07b6408c41cb55122169739e4bdce626660c109",
-      "integrity": "sha512-TjQIvXi2Pu7/836bSdFQ9yvN12T/hO4nixHK0Mus/OoQo7WlxzrBcnZ0RJbBSHnOCE19OflU7OQ1dC08T0beuw==",
+      "resolved": "git+https://git@github.com/NikolaBalaban/mic-recorder-to-mp3.git#b07b6408c41cb55122169739e4bdce626660c109",
       "license": "MIT",
       "dependencies": {
         "lamejs": "^1.2.0"
@@ -5960,9 +5959,9 @@
       }
     },
     "node_modules/webrtc-adapter": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-8.1.0.tgz",
-      "integrity": "sha512-I+y/LWBiGYPVhIb8Ww7nyoNWhrCYENeGoRvZuyytLn/h+ahDBgItvuIfMdzT+xhOnjLIMVkOykttGJPv1dr6kA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-8.1.2.tgz",
+      "integrity": "sha512-j1tsxKR/NmNgqrlLTL5jsNmFBrsIdTvBWZ2I1UAs/J37M1s1chLy1Fp7RfQHflHk3KoSNAxp/4y6ictHJ8prSw==",
       "peer": true,
       "dependencies": {
         "sdp": "^3.0.2"
@@ -9483,9 +9482,8 @@
       "dev": true
     },
     "mic-recorder-to-mp3": {
-      "version": "git+ssh://git@github.com/NikolaBalaban/mic-recorder-to-mp3.git#b07b6408c41cb55122169739e4bdce626660c109",
-      "integrity": "sha512-TjQIvXi2Pu7/836bSdFQ9yvN12T/hO4nixHK0Mus/OoQo7WlxzrBcnZ0RJbBSHnOCE19OflU7OQ1dC08T0beuw==",
-      "from": "mic-recorder-to-mp3@git+https://github.com/NikolaBalaban/mic-recorder-to-mp3.git",
+      "version": "git+https://git@github.com/NikolaBalaban/mic-recorder-to-mp3.git#b07b6408c41cb55122169739e4bdce626660c109",
+      "from": "mic-recorder-to-mp3@https://git@github.com/NikolaBalaban/mic-recorder-to-mp3.git",
       "requires": {
         "lamejs": "^1.2.0"
       }
@@ -10553,9 +10551,9 @@
       "dev": true
     },
     "webrtc-adapter": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-8.1.0.tgz",
-      "integrity": "sha512-I+y/LWBiGYPVhIb8Ww7nyoNWhrCYENeGoRvZuyytLn/h+ahDBgItvuIfMdzT+xhOnjLIMVkOykttGJPv1dr6kA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-8.1.2.tgz",
+      "integrity": "sha512-j1tsxKR/NmNgqrlLTL5jsNmFBrsIdTvBWZ2I1UAs/J37M1s1chLy1Fp7RfQHflHk3KoSNAxp/4y6ictHJ8prSw==",
       "peer": true,
       "requires": {
         "sdp": "^3.0.2"

--- a/axolotl-web/package.json
+++ b/axolotl-web/package.json
@@ -29,7 +29,7 @@
     "file-saver": "^2.0.5",
     "linkify-html": "^3.0.4",
     "linkifyjs": "^3.0.4",
-    "mic-recorder-to-mp3": "git+https://github.com/NikolaBalaban/mic-recorder-to-mp3.git",
+    "mic-recorder-to-mp3": "https://git@github.com/NikolaBalaban/mic-recorder-to-mp3.git",
     "moment": "^2.29.4",
     "qrcode": "1.4.4 || ^1.5.1",
     "vue": "^3.2.37",


### PR DESCRIPTION
Adjust format used for mic-recorder-to-mp3 npm git dependency and update npm lock file.

The format used is based on the minimal-git node flatpak-builder-tools test case

https://github.com/flatpak/flatpak-builder-tools/blob/master/node/tests/data/packages/minimal-git/package.json

This should solve https://github.com/nanu-c/axolotl/issues/838

This bug has two related issues in flatpak-builder-tools:

* https://github.com/flatpak/flatpak-builder-tools/issues/182
* https://github.com/flatpak/flatpak-builder-tools/issues/237