### PR TITLE
Flatpak CI builds: specify branch to use

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -207,6 +207,7 @@ jobs:
           bundle: axolotl-web.flatpak
           manifest-path: flatpak/web/org.nanuc.Axolotl.yml
           cache-key: flatpak-builder-web-${{ github.sha }}
+          branch: ${{ github.ref_name }}
 
   package-flatpak-qt:
     name: Package as Flatpak QT bundle
@@ -227,6 +228,7 @@ jobs:
           bundle: axolotl-qt.flatpak
           manifest-path: flatpak/qt/org.nanuc.Axolotl.yml
           cache-key: flatpak-builder-qt-${{ github.sha }}
+          branch: ${{ github.ref_name }}
 
   package-deb-arm64:
     name: Package as Debian arm64


### PR DESCRIPTION
The previous flatpak builds defaulted to the "main" branch always: also when building within a PR. This overrides the branch to use and specifies it to the branch or tag name that triggered the workflow run.

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

https://github.com/flatpak/flatpak-github-actions#inputs