### PR TITLE
Flatpak CI builds: Address crayfish build errors

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -202,7 +202,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf-lite
+        run: dnf -y install protobuf-lite-devel
 
       - name: Build Flatpak Web version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
@@ -225,7 +225,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf-lite
+        run: dnf -y install protobuf-lite-devel
 
       - name: Build Flatpak QT version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -201,6 +201,9 @@ jobs:
         with:
           submodules: 'true'
 
+      - name: Install build dependencies
+        run: dnf -y install protobuf-lite
+
       - name: Build Flatpak Web version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
         with:
@@ -220,6 +223,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
+
+      - name: Install build dependencies
+        run: dnf -y install protobuf-lite
 
       - name: Build Flatpak QT version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -202,7 +202,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf-compiler
+        run: dnf -y install protobuf-devel protobuf-compiler
 
       - name: Build Flatpak Web version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
@@ -225,7 +225,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf-compiler
+        run: dnf -y install protobuf-devel protobuf-compiler
 
       - name: Build Flatpak QT version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -202,7 +202,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf-lite-devel
+        run: dnf -y install protobuf
 
       - name: Build Flatpak Web version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
@@ -225,7 +225,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf-lite-devel
+        run: dnf -y install protobuf
 
       - name: Build Flatpak QT version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -202,7 +202,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf
+        run: dnf -y install protobuf-compiler
 
       - name: Build Flatpak Web version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
@@ -225,7 +225,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf
+        run: dnf -y install protobuf-compiler
 
       - name: Build Flatpak QT version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -202,7 +202,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf-devel protobuf-compiler
+        run: dnf -y install gcc g++ protobuf-devel protobuf-compiler
 
       - name: Build Flatpak Web version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
@@ -225,7 +225,7 @@ jobs:
           submodules: 'true'
 
       - name: Install build dependencies
-        run: dnf -y install protobuf-devel protobuf-compiler
+        run: dnf -y install gcc g++ protobuf-devel protobuf-compiler
 
       - name: Build Flatpak QT version
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4


### PR DESCRIPTION
Attempt to address the flatpak cmake build errors by manually install the missing protobuf dependency.