### PR TITLE
Upgrade astilectron bundler to v0.56.0

### DIFF
--- a/bundler.json
+++ b/bundler.json
@@ -3,6 +3,6 @@
   "icon_path_darwin": "axolotl-web/public/axolotl.png",
   "icon_path_linux": "axolotl-web/public/axolotl.png",
   "version_electron": "18.0.1",
-  "version_astilectron":"0.55.0",
+  "version_astilectron":"0.56.0",
   "resources_path": "axolotl-web/dist"
 }

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func runElectron() {
 		AppIconDarwinPath:  "axolotl-web/public/axolotl.png", // Same here
 		BaseDirectoryPath:  electronPath,
 		VersionElectron:    "18.0.1",
-		VersionAstilectron: "0.55.0",
+		VersionAstilectron: "0.56.0",
 		SingleInstance:     true,
 		ElectronSwitches:   electronSwitches,
 	}


### PR DESCRIPTION
There has been some a new version of released of the astilectron electron bundler.

As to keep up to date and allow using the latest and greatest, this PR updates the version to the latest release as of today, 0.56.0.

https://github.com/asticode/astilectron/releases/tag/v0.56.0
