### PR TITLE
fixes a few minor typos; "'I' before 'E' except after 'C'"

### DIFF
--- a/app/webserver/handler.go
+++ b/app/webserver/handler.go
@@ -26,13 +26,13 @@ var (
 	requestUsername            = false
 )
 
-type MessageRecieved struct {
-	MessageRecieved *store.Message
+type MessageReceived struct {
+	MessageReceived *store.Message
 }
 
 func MessageHandler(msg *store.Message) {
-	messageRecieved := &MessageRecieved{
-		MessageRecieved: msg,
+	messageReceived := &MessageReceived{
+		MessageReceived: msg,
 	}
 	// fetch attached message
 	if msg.Flags == helpers.MsgFlagQuote {
@@ -47,7 +47,7 @@ func MessageHandler(msg *store.Message) {
 	}
 	var err error
 	message := &[]byte{}
-	*message, err = json.Marshal(messageRecieved)
+	*message, err = json.Marshal(messageReceived)
 	if err != nil {
 		log.Errorln("[axolotl-ws] messageHandler", err)
 		return

--- a/axolotl-web/src/components/Message.vue
+++ b/axolotl-web/src/components/Message.vue
@@ -336,8 +336,8 @@ export default {
       }
     },
     timerPercentage(m) {
-      const recieved = moment(m.ReceivedAt);
-      const duration = moment.duration(recieved.diff(moment.now()));
+      const received = moment(m.ReceivedAt);
+      const duration = moment.duration(received.diff(moment.now()));
       const percentage =
         1 - (m.ExpireTimer + duration.asSeconds()) / m.ExpireTimer;
       if (percentage < 1) {
@@ -350,8 +350,8 @@ export default {
         // console.log(m.ExpireTimer,m.SentAt, m.ReceivedAt, Date.now())
         if (m.ReceivedAt !== 0) {
           // hide destructed messages but not timer settings
-          const recieved = moment(m.ReceivedAt);
-          const duration = moment.duration(recieved.diff(moment.now()));
+          const received = moment(m.ReceivedAt);
+          const duration = moment.duration(received.diff(moment.now()));
           if (duration.asSeconds() + m.ExpireTimer < 0) {
             this.$store.dispatch("deleteSelfDestructingMessage", m);
             return false;

--- a/axolotl-web/src/store/store.js
+++ b/axolotl-web/src/store/store.js
@@ -167,7 +167,7 @@ export default createStore({
         state.messageList.Messages = state.messageList.Messages.concat(messageList.Messages);
       }
     },
-    SET_MESSAGE_RECIEVED(state, message) {
+    SET_MESSAGE_RECEIVED(state, message) {
       if (state.messageList.ID === message.SID) {
         const tmpList = state.messageList.Messages;
         tmpList.push(message);
@@ -301,8 +301,8 @@ export default createStore({
         else if (Object.keys(messageData)[0] === "DeviceList") {
           this.commit("SET_DEVICELIST", messageData["DeviceList"]);
         }
-        else if (Object.keys(messageData)[0] === "MessageRecieved") {
-          this.commit("SET_MESSAGE_RECIEVED", messageData["MessageRecieved"]);
+        else if (Object.keys(messageData)[0] === "MessageReceived") {
+          this.commit("SET_MESSAGE_RECEIVED", messageData["MessageReceived"]);
         }
         else if (Object.keys(messageData)[0] === "UpdateMessage") {
           this.commit("SET_MESSAGE_UPDATE", messageData["UpdateMessage"]);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -365,7 +365,7 @@ Bugfixes:
 
 0.7.2.1 (Dez 3 2019)
 --------------------
-* qUICK FIX FOr handling recieved messages
+* qUICK FIX FOr handling received messages
 
 0.7.2 (Dez 2 2019) Axolotl-Beta: second beta version
 --------------------


### PR DESCRIPTION
Was hoping the source for the accompanying site at https://axolotl.chat/ was included in this repo, but without digging too far it doesn't seem to be. Anyways, just a quick skim to fix these typos.

Quickly done with:
```
grep -irl recieve | xargs -I{} sed -i 's/Recieve/Receive/g' '{}'
grep -irl recieve | xargs -I{} sed -i 's/recieve/receive/g' '{}'
grep -irl recieve | xargs -I{} sed -i 's/RECIEVE/RECEIVE/g' '{}'
```

With the Pixel 3a having _exceptional_ Ubuntu Touch support, I'm hoping to (along with a waterproof case) finally have a replacement for my Pixel 3 as a daily driver on the ski kill; antithetically, one with a reasonably decent user experience, uncrippled by a poorly implemented operating system overcasting the solid foundational Linux kernel beneath it.

I plan to use `nanu-c/axolotl` as a basis, along with https://docs.ubports.com/en/latest/appdev/guides/pushnotifications.html and https://gitlab.com/ubports/development/core/lomiri-push-service/-/tree/main/server , to fulfill the need for push notifications with regards to Signal - albeit, it may be more towards replacing the direct-to-Signal connection in this project with a connection to a proxy implemented around https://github.com/AsamK/signal-cli

Thanks for the inspiration, @nanu-c 