### PR TITLE
Upgrade to bundled Electron version 20.x

### DIFF
--- a/bundler.json
+++ b/bundler.json
@@ -2,7 +2,7 @@
   "app_name": "axolotl-electron-bundle",
   "icon_path_darwin": "axolotl-web/public/axolotl.png",
   "icon_path_linux": "axolotl-web/public/axolotl.png",
-  "version_electron": "18.0.1",
+  "version_electron": "20.2.0",
   "version_astilectron":"0.56.0",
   "resources_path": "axolotl-web/dist"
 }

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func runElectron() {
 		AppIconDefaultPath: "axolotl-web/public/axolotl.png", // If path is relative, it must be relative to the data directory
 		AppIconDarwinPath:  "axolotl-web/public/axolotl.png", // Same here
 		BaseDirectoryPath:  electronPath,
-		VersionElectron:    "18.0.1",
+		VersionElectron:    "20.2.0",
 		VersionAstilectron: "0.56.0",
 		SingleInstance:     true,
 		ElectronSwitches:   electronSwitches,


### PR DESCRIPTION
As to keep on top of the Electron releases, up it from v18 to the latest stable release, v20.x

https://www.electronjs.org/releases/stable

https://github.com/electron/electron/releases/tag/v20.2.0