### PR TITLE
Faster getLastMessagesForAllSessions

### DIFF
--- a/app/store/message.go
+++ b/app/store/message.go
@@ -11,6 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const getLastMessagesQuery = "SELECT *, max(sentat) FROM messages GROUP BY sid ORDER BY sentat DESC"
+
 type Message struct {
 	ID            int64 `db:"id"`
 	SID           int64
@@ -167,17 +169,14 @@ func GetUnreadMessageCounterForSession(id int64) (int64, error) {
 	return int64(len(message)), nil
 }
 
-// GetLastMessageForSession returns the last message in a session
-func GetLastMessageForSession(id int64) (*Message, error) {
-	var message = []Message{}
-	err := DS.Dbx.Select(&message, "SELECT id FROM messages WHERE sid = ? ORDER BY sentat DESC LIMIT 1", id)
+func GetLastMessagesForAllSessions() ([]Message, error) {
+	var messages = []Message{}
+	unsafeDbx := DS.Dbx.Unsafe() // needed, because max(sentat) has no destination
+	err := unsafeDbx.Select(&messages, getLastMessagesQuery)
 	if err != nil {
 		return nil, err
 	}
-	if len(message) == 0 {
-		return nil, errors.New("Message not found " + fmt.Sprint(id))
-	}
-	return &message[0], nil
+	return messages, nil
 }
 
 func getMessagesForSession(id int64, limit, offset int) ([]*Message, error) {

--- a/app/store/sessionV2.go
+++ b/app/store/sessionV2.go
@@ -251,22 +251,6 @@ func (s *SessionsV2) GetSessionNames() ([]SessionV2Name, error) {
 	}
 	return names, nil
 }
-func (s *SessionsV2) GetLastMessagesForAllSessions() ([]Message, error) {
-	var messages = []Message{}
-	var sessions = []Session{}
-	err := DS.Dbx.Select(&sessions, "SELECT id FROM sessionsv2")
-	if err != nil {
-		return nil, err
-	}
-	for i := range sessions {
-		s := sessions[i]
-		m, err := GetLastMessageForSession(s.ID)
-		if err == nil {
-			messages = append(messages, *m)
-		}
-	}
-	return messages, nil
-}
 
 // isGroup returns true if the session is a group session
 func (s *SessionV2) IsGroup() bool {

--- a/app/webserver/helpers.go
+++ b/app/webserver/helpers.go
@@ -50,7 +50,7 @@ func sendChatList() {
 		log.Errorln("[axolotl] sendChatList1", err)
 		return
 	}
-	lastMessages, err := store.SessionsV2Model.GetLastMessagesForAllSessions()
+	lastMessages, err := store.GetLastMessagesForAllSessions()
 	if err != nil {
 		log.Errorln("[axolotl] sendChatList2", err)
 		return


### PR DESCRIPTION
I found a way to implement this with one database query.
It does not fail if a session has no message though.