### PR TITLE
Change the way MicRecorder is imported

### DIFF
--- a/axolotl-web/src/pages/MessageList.vue
+++ b/axolotl-web/src/pages/MessageList.vue
@@ -177,7 +177,7 @@ import Message from "@/components/Message";
 import AttachmentBar from "@/components/AttachmentBar";
 import DefaultLayout from "@/layouts/Default";
 import { saveAs } from "file-saver";
-import * as MicRecorder from "@jmd01/mic-recorder-to-mp3";
+import MicRecorder from "@jmd01/mic-recorder-to-mp3";
 export default {
   name: "MessageList",
   components: {


### PR DESCRIPTION
The old way of importing this did not work while running clickable desktop.
Hopefully this way works in all scenarios.