### PR TITLE
v1.6.0

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -18,7 +18,7 @@ import (
 
 const AppName = "textsecure.nanuc"
 
-const AppVersion = "1.5.1"
+const AppVersion = "1.6.0"
 
 // MaxAttachmentSize does not allow sending attachments larger than 100M for now
 const MaxAttachmentSize int64 = 100 * 1024 * 1024

--- a/appimage/AppDir/axolotl.appdata.xml
+++ b/appimage/AppDir/axolotl.appdata.xml
@@ -29,6 +29,9 @@
         </screenshot>
     </screenshots>
     <releases>
+		<release version="1.6.0" date="2022-10-27">
+ 				<url>https://github.com/nanu-c/axolotl/releases/tag/v1.6.0</url>
+ 		</release>
 		<release version="1.5.1" date="2022-09-20">
  				<url>https://github.com/nanu-c/axolotl/releases/tag/v1.5.1</url>
  		</release>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.6.0 (Oct 27 2022)
+------------------------------------
+* rewrite the internal data structure @nanu-c @Blackoverflow
+* fix attachments upload @Blackoverflow
+* update root ca @nuehm-arno
+* Add Profiles @nanu-c
+* Add support for profile images @nanu-c
+* update electron @olof-nord
+* update various dependencies @nanu-c
+
 1.5.1 (Sep 20 2022)
 ------------------------------------
 * fix mic-recorder-to-mp3 dependency @olof-nord

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -135,7 +135,7 @@ To build the application, use the following command from the root of this reposi
 
 To install the built snap, use snap:
 
-`sudo snap install axolotl_1.5.1_amd64.snap --dangerous`
+`sudo snap install axolotl_1.6.0_amd64.snap --dangerous`
 
 **Run**
 

--- a/flatpak/org.nanuc.Axolotl.appdata.xml
+++ b/flatpak/org.nanuc.Axolotl.appdata.xml
@@ -29,6 +29,9 @@
         </screenshot>
     </screenshots>
     <releases>
+		<release version="1.6.0" date="2022-10-27">
+ 				<url>https://github.com/nanu-c/axolotl/releases/tag/v1.6.0</url>
+ 		</release>
 		<release version="1.5.1" date="2022-09-20">
  				<url>https://github.com/nanu-c/axolotl/releases/tag/v1.5.1</url>
  		</release>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "textsecure.nanuc",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "description": "A Signal compatible messaging client for Ubuntu phones",
     "title": "Axolotl",
     "architecture": "@CLICK_ARCH@",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ grade: stable
 confinement: strict
 base: core20
 icon: snap/gui/axolotl.png
-version: "1.5.1"
+version: "1.6.0"
 architectures:
   - build-on: amd64
   - build-on: arm64


### PR DESCRIPTION
1.6.0 (Oct 27 2022)
------------------------------------
* rewrite the internal data structure @nanu-c @Blackoverflow
* fix attachments upload @Blackoverflow
* update root ca @nuehm-arno
* Add Profiles @nanu-c
* Add support for profile images @nanu-c
* update electron @olof-nord
* update various dependencies @nanu-c