### PR TITLE
Update bundled electron to v21.x

### DIFF
--- a/bundler.json
+++ b/bundler.json
@@ -2,7 +2,7 @@
   "app_name": "axolotl-electron-bundle",
   "icon_path_darwin": "axolotl-web/public/axolotl.png",
   "icon_path_linux": "axolotl-web/public/axolotl.png",
-  "version_electron": "20.2.0",
+  "version_electron": "21.0.1",
   "version_astilectron":"0.56.0",
   "resources_path": "axolotl-web/dist"
 }

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func runElectron() {
 		AppIconDefaultPath: "axolotl-web/public/axolotl.png", // If path is relative, it must be relative to the data directory
 		AppIconDarwinPath:  "axolotl-web/public/axolotl.png", // Same here
 		BaseDirectoryPath:  electronPath,
-		VersionElectron:    "20.2.0",
+		VersionElectron:    "21.0.1",
 		VersionAstilectron: "0.56.0",
 		SingleInstance:     true,
 		ElectronSwitches:   electronSwitches,


### PR DESCRIPTION
Specify the latest 21.x version of Electron to use when using the bundler.

https://www.electronjs.org/releases/stable