### PR TITLE
Add keys to improve handling of Axolotl in Phosh

### DIFF
--- a/deb/axolotl.desktop
+++ b/deb/axolotl.desktop
@@ -11,3 +11,5 @@ Categories=Network;Chat;InstantMessaging
 StartupWMClass=axolotl
 X-KDE-FormFactor=desktop;tablet;handset;
 X-Purism-FormFactor=Workstation;Mobile; 
+StartupNotify=true
+X-Gnome-UsesNotifications=true

--- a/flatpak/qt/org.nanuc.Axolotl.desktop
+++ b/flatpak/qt/org.nanuc.Axolotl.desktop
@@ -10,3 +10,5 @@ Categories=Network;InstantMessaging;Chat;
 Icon=org.nanuc.Axolotl
 X-KDE-FormFactor=desktop;tablet;handset;
 X-Purism-FormFactor=Workstation;Mobile; 
+StartupNotify=true
+X-Gnome-UsesNotifications=true

--- a/flatpak/web/org.nanuc.Axolotl.desktop
+++ b/flatpak/web/org.nanuc.Axolotl.desktop
@@ -10,3 +10,5 @@ Categories=Network;InstantMessaging;Chat;
 Icon=org.nanuc.Axolotl
 X-KDE-FormFactor=desktop;tablet;handset;
 X-Purism-FormFactor=Workstation;Mobile;
+StartupNotify=true
+X-Gnome-UsesNotifications=true


### PR DESCRIPTION
StartupNotify enables showing the icon fullscreen for a short period of time after starting Axolotl.
UsesNotifications puts Axolotl in the GNOME notifications app list.