### PR TITLE
Update base Flatpak SDK to 22.08

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -192,7 +192,7 @@ jobs:
     name: Package as Flatpak web bundle
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:freedesktop-21.08
+      image: bilelmoussaoui/flatpak-github-actions:freedesktop-22.08
       options: --privileged
 
     steps:
@@ -213,7 +213,7 @@ jobs:
     name: Package as Flatpak QT bundle
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-21.08
+      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-22.08
       options: --privileged
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -184,19 +184,19 @@ install-axolotl-electron-bundle:
 
 ## Flatpak
 build-dependencies-flatpak:
-	$(FLATPAK) install org.freedesktop.Sdk.Extension.golang//21.08
-	$(FLATPAK) install org.freedesktop.Sdk.Extension.node18//21.08
-	$(FLATPAK) install org.freedesktop.Sdk.Extension.rust-stable//21.08
+	$(FLATPAK) install org.freedesktop.Sdk.Extension.golang//22.08
+	$(FLATPAK) install org.freedesktop.Sdk.Extension.node18//22.08
+	$(FLATPAK) install org.freedesktop.Sdk.Extension.rust-stable//22.08
 
 build-dependencies-flatpak-web: build-dependencies-flatpak
-	$(FLATPAK) install org.freedesktop.Platform//21.08
-	$(FLATPAK) install org.freedesktop.Sdk//21.08
-	$(FLATPAK) install org.electronjs.Electron2.BaseApp//21.08
+	$(FLATPAK) install org.freedesktop.Platform//22.08
+	$(FLATPAK) install org.freedesktop.Sdk//22.08
+	$(FLATPAK) install org.electronjs.Electron2.BaseApp//22.08
 
 build-dependencies-flatpak-qt: build-dependencies-flatpak
-	$(FLATPAK) install org.kde.Platform//5.15-21.08
-	$(FLATPAK) install org.kde.Sdk//5.15-21.08
-	$(FLATPAK) install io.qt.qtwebengine.BaseApp//5.15-21.08
+	$(FLATPAK) install org.kde.Platform//5.15-22.08
+	$(FLATPAK) install org.kde.Sdk//5.15-22.08
+	$(FLATPAK) install io.qt.qtwebengine.BaseApp//5.15-22.08
 
 build-flatpak-web:
 	$(FLATPAK_BUILDER) flatpak/build --verbose --force-clean --ccache flatpak/web/org.nanuc.Axolotl.yml

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -156,12 +156,12 @@ Installation instructions can be found [here](https://flatpak.org/setup/)
 
 The following Flatpak SDKs are required:
 ```
-flatpak install org.freedesktop.Platform//21.08
-flatpak install org.freedesktop.Sdk//21.08
-flatpak install org.freedesktop.Sdk.Extension.golang//21.08
-flatpak install org.freedesktop.Sdk.Extension.node18//21.08
-flatpak install org.freedesktop.Sdk.Extension.rust-stable//21.08
-flatpak install org.electronjs.Electron2.BaseApp//21.08
+flatpak install org.freedesktop.Platform//22.08
+flatpak install org.freedesktop.Sdk//22.08
+flatpak install org.freedesktop.Sdk.Extension.golang//22.08
+flatpak install org.freedesktop.Sdk.Extension.node18//22.08
+flatpak install org.freedesktop.Sdk.Extension.rust-stable//22.08
+flatpak install org.electronjs.Electron2.BaseApp//22.08
 ```
 
 **Build and Install**
@@ -194,12 +194,12 @@ To start the application, either search for "Axolotl" in your app drawer or star
 
 The following Flatpak SDKs are required:
 ```
-flatpak install org.kde.Platform//5.15-21.08
-flatpak install org.kde.Sdk//5.15-21.08
-flatpak install org.freedesktop.Sdk.Extension.golang//21.08
-flatpak install org.freedesktop.Sdk.Extension.node18//21.08
-flatpak install org.freedesktop.Sdk.Extension.rust-stable//21.08
-flatpak install io.qt.qtwebengine.BaseApp//5.15-21.08
+flatpak install org.kde.Platform//5.15-22.08
+flatpak install org.kde.Sdk//5.15-22.08
+flatpak install org.freedesktop.Sdk.Extension.golang//22.08
+flatpak install org.freedesktop.Sdk.Extension.node18//22.08
+flatpak install org.freedesktop.Sdk.Extension.rust-stable//22.08
+flatpak install io.qt.qtwebengine.BaseApp//5.15-22.08
 ```
 
 **Build and Install**

--- a/flatpak/qt/org.nanuc.Axolotl.yml
+++ b/flatpak/qt/org.nanuc.Axolotl.yml
@@ -1,7 +1,7 @@
 app-id: org.nanuc.Axolotl
 branch: main
 runtime: org.kde.Platform
-runtime-version: '5.15-21.08'
+runtime-version: '5.15-22.08'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
@@ -9,7 +9,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
 command: axolotl
 base: io.qt.qtwebengine.BaseApp
-base-version: '5.15-21.08'
+base-version: '5.15-22.08'
 separate-locales: false
 tags:
   - latest

--- a/flatpak/web/org.nanuc.Axolotl.yml
+++ b/flatpak/web/org.nanuc.Axolotl.yml
@@ -1,7 +1,7 @@
 app-id: org.nanuc.Axolotl
 branch: main
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.golang
@@ -9,7 +9,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
 command: run.sh
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 separate-locales: false
 tags:
   - latest


### PR DESCRIPTION
With Flatpak SDK 22.08 now released, update our dependencies to 22.08.

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases

To try out locally:

```shell
make build-dependencies-flatpak-web
make install-flatpak-web
flatpak run org.nanuc.Axolotl
```