### PR TITLE
Add the feature to send an attachment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ name = "axolotl"
 version = "0.1.0"
 dependencies = [
  "clap 4.1.1",
+ "data-url",
  "dbus",
  "dirs",
  "env_logger 0.10.0",
@@ -970,6 +971,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
 name = "dbus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4.1.1", features = ["derive"] }
 dirs = "4.0.0"
 serve-directory = "0.1.0"
 notify-rust = { version = "4.6.0", optional = true}
+data-url = "0.2.0"
 
 dbus = { version = "0.9", optional = true}
 

--- a/axolotl-web/src/pages/MessageList.vue
+++ b/axolotl-web/src/pages/MessageList.vue
@@ -155,14 +155,12 @@
           @close="showAttachmentsBar = false"
           @send="callContentHub($event)"
         />
-        <!--  TODO: Fix attachment sending
         <input
-          v-if="false" 
           id="attachment"
           type="file"
-          style="position: fixed; top: -100em"
           @change="sendDesktopAttachment"
         />
+	<!--  TODO: Fix attachment sending
         <audio
           id="voiceNote"
           :src="voiceNote.blobUrl"

--- a/axolotl-web/src/store/store.js
+++ b/axolotl-web/src/store/store.js
@@ -699,12 +699,13 @@ export default createStore({
     },
     uploadAttachment(state, attachment) {
       if (this.state.socket.isConnected) {
+        let data = {
+          "attachment": attachment.attachment,
+          "recipient": attachment.to,
+        };
         const message = {
           "request": "uploadAttachment",
-          "data": {
-            "attachment": attachment.attachment,
-            "to": attachment.to,
-          }
+          "data": JSON.stringify(data)
         }
         socketSend(message);
       }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,29 +1,117 @@
 //! The messages module
 
-use std::time::UNIX_EPOCH;
-use presage::prelude::*;
-use presage::{Manager, SledStore};
-
+use crate::error::ApplicationError;
 use crate::manager_thread::ManagerThread;
+use crate::requests::{AxolotlMessage, AxolotlResponse, SendMessageResponse};
+use presage::prelude::proto::AttachmentPointer;
+use presage::prelude::*;
+use presage::{Manager, SledStore, Thread};
+use std::time::UNIX_EPOCH;
 
 /**
- * Send a message to one people.
+ * Send a message to one people or a group.
  * 
- * Currently it only sends text message. TODO: make it more abstract to send pictures and so on. 
+ * - recipient is a String containing the UUID of the recipient. A contact or a
+ *   group, both are supported.
+ * - msg is an optional String containing the text body of the message. Most messages
+ *   would have it.
+ * - attachments is an optional Vec of AttachmentPointer. The attachments must be
+ *   already uploaded, here they are only sent.
+ * - manager is the instance of ManagerThread.
+ * - response_type is a string slice containing the Axolotl response type. This
+ *   parameter is mandatory because the method is used to send message but also to
+ *   send attachments. Could be removed in the future if both handlers are merged.
  */
-pub async fn send_message(msg: String, uuid: Uuid, manager: &ManagerThread)
+pub async fn send_message(
+    recipient: String,
+    msg: Option<String>,
+    attachments: Option<Vec<AttachmentPointer>>,
+    manager: &ManagerThread,
+    response_type: &str
+) -> Result<AxolotlResponse, ApplicationError>
 {
-    // Send message
+    log::info!("Sending a message.");
     let timestamp = std::time::SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards")
         .as_millis() as u64;
-    let message = ContentBody::DataMessage(DataMessage {
-        body: Some(msg.to_string()),
+
+    // Add the attachments to the message, if any
+    let mut attachments_vec = Vec::new();
+    if let Some(a) = attachments {
+        attachments_vec = a;
+    }
+
+    log::debug!("Sending {} attachments", attachments_vec.len());
+    let data_message = DataMessage {
+        body: msg,
         timestamp: Some(timestamp),
+        attachments: attachments_vec,
         ..Default::default()
-    });
-    manager.send_message(uuid, message, timestamp).await.unwrap();     
+    };
+
+    // Search the recipient's UUID. A contact or a group
+    let thread = match Thread::try_from(&recipient) {
+        Ok(t) => t,
+        Err(e) => {
+            log::error!("Error while parsing the request. {:?}", e);
+            return Err(ApplicationError::InvalidRequest);
+        }
+    };
+
+    let result = match thread {
+        Thread::Contact(contact) => {
+            log::debug!("Sending a message to a contact.");
+            let message = ContentBody::DataMessage(data_message.clone());
+            manager
+                .send_message(contact, message.clone(), timestamp)
+                .await
+        }
+        Thread::Group(group) => {
+            log::debug!("Sending a message to a group.");
+            let group_master_key = GroupMasterKey::new(group.clone());
+            let group_from_store =
+                manager.get_group_v2(group_master_key).await.ok().unwrap();
+            let group_members = group_from_store.members.iter();
+            let mut group_members_service_addresses: Vec<ServiceAddress> = Vec::new();
+
+            for member in group_members {
+                group_members_service_addresses.push(ServiceAddress {
+                    uuid: Some(member.uuid.clone()),
+                    phonenumber: None,
+                    relay: None,
+                });
+            }
+            let mut group_data_message = data_message.clone();
+            group_data_message.group_v2 = Some(GroupContextV2 {
+                master_key: Some(group.to_vec()),
+                group_change: None,
+                revision: Some(group_from_store.version),
+            });
+            manager
+                .send_message_to_group(
+                    group_members_service_addresses,
+                    group_data_message,
+                    timestamp,
+                )
+                .await
+        }
+    };
+
+    let is_failed = result.is_err();
+    if is_failed {
+        log::error!("Error while sending the message. {:?}", result.err());
+    }
+    let mut message = AxolotlMessage::from_data_message(data_message);
+    message.thread_id = Some(thread.to_string());
+    message.sender = Some(manager.uuid());
+    let response_data = SendMessageResponse { message, is_failed };
+    let response_data_json = serde_json::to_string(&response_data).unwrap();
+    let response = AxolotlResponse {
+        response_type: response_type.to_string(),
+        data: response_data_json,
+    };
+    Ok(response)
 }
 
 pub async fn send_message_to_group(msg: &str, master_key_str: &str, config_store: SledStore)

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -18,6 +18,14 @@ pub struct SendMessageRequest {
 }
 
 #[derive(Deserialize, Debug)]
+pub struct UploadAttachmentRequest {
+    // The data URL containing the base64-encoded file
+    pub attachment: String,
+    // The uuid
+    pub recipient: String,
+}
+
+#[derive(Deserialize, Debug)]
 pub struct LinkDeviceRequest {
     pub device_name: String,
 }


### PR DESCRIPTION
The send message handler has been partially moved to messages.rs to wrap the logic in a function send_message(). By doing so, both the send message and the send attachment handlers use the same function and avoid duplicate code.

In the future, it should be easy to change the send attachment feature to:
1. Wait for the user to confirm before sending the attachment.
2. Add text with the attachment.

On the front end, the button to add an attachment has no style, it's just a default button.