### PR TITLE
Install axolotlweb artifacts into its install dir (UT)

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -30,9 +30,9 @@ jobs:
         uses: ChristopherHX/conditional@b4a9649204f81002ec9a4ef7d4bf7d6b2ab7fa55
         with:
           step: |
-            uses: docker://clickable/ci-20.04-${{ matrix.arch }}:7.11.0
+            uses: docker://clickable/ci-20.04-${{ matrix.arch }}:7.12.3
             with:
-              args: clickable build --verbose -a ${{ matrix.arch }} --app
+              args: clickable build --verbose -a ${{ matrix.arch }} --all
 
       - name: Upload the built click artifact (${{ matrix.arch }})
         uses: actions/upload-artifact@v3

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,18 +1,15 @@
 clickable_minimum_required: 7.12.3
 
 builder: rust
-rust_channel: 1.71.1
-env_vars:
-  CC: ""
-  CXX: ""
+rust_channel: 1.72.1
+build_args: --features ut
+
 dependencies_host:
   - gettext
   - protobuf-compiler
-  
 dependencies_target:
   - libdbus-1-dev
 
-build_args: --features ut 
 kill: axolotl
 framework: ubuntu-sdk-20.04
 
@@ -48,4 +45,4 @@ libraries:
     build:
       - cd ${SRC_DIR} && npm ci && npm run build
       - mkdir -p ${INSTALL_DIR}/axolotl-web
-      - cp ${SRC_DIR}/dist ${INSTALL_DIR}/axolotl-web/ -R
+      - mv ${SRC_DIR}/dist ${INSTALL_DIR}/axolotl-web/

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,13 +1,10 @@
-clickable_minimum_required: 7.10.0
+clickable_minimum_required: 7.12.3
 
 builder: rust
 rust_channel: 1.66.1
 env_vars:
   CC: ""
   CXX: ""
-prebuild: 
-  - mkdir -p ${BUILD_DIR}/axolotl-web 
-  - cp ${SRC_DIR}/axolotl-web/dist ${BUILD_DIR}/axolotl-web/ -R
 dependencies_host:
   - gettext
   - protobuf-compiler
@@ -32,7 +29,7 @@ install_root_data:
   - click/textsecure.desktop
   - click/textsecure.png
   - click/textsecure.url-dispatcher
-  - ${BUILD_DIR}/axolotl-web
+  - ${AXOLOTLWEB_LIB_INSTALL_DIR}/axolotl-web
   - guis/qml/ut
 
 libraries:
@@ -45,6 +42,9 @@ libraries:
         - echo "NPM Version:" && npm --version
 
     builder: custom
+    restrict_arch: all
     src_dir: axolotl-web
     build:
-      - cd ../../../axolotl-web/ && npm ci && npm run build
+      - cd ${SRC_DIR} && npm ci && npm run build
+      - mkdir -p ${INSTALL_DIR}/axolotl-web
+      - cp ${SRC_DIR}/dist ${INSTALL_DIR}/axolotl-web/ -R


### PR DESCRIPTION
This PR makes a small change by letting the `axolotlweb` build config store its artifacts into its install directory, instead of copying from the source directory into axolotls build directory before each build of the app.

ToDo:

- [x] Wait for release of [this Clickable fix](https://gitlab.com/clickable/clickable/-/merge_requests/595) and require the corresponding version
- [x] Wait for the [Clickable CI images](https://gitlab.com/clickable/clickable-docker-images/-/pipelines) to be fixed
- [x] Fix artifact paths in CI