### PR TITLE
Separate functions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,66 +25,54 @@ impl std::fmt::Display for ApplicationError {
         match self {
             ApplicationError::ManagerThreadPanic => writeln!(
                 f,
-                "{}",
                 "A part of the application crashed."
             ),
             ApplicationError::NoInternet => writeln!(
                 f,
-                "{}",
                 "There does not seem to be a connection to the internet available."
             ),
 
             ApplicationError::UnauthorizedSignal => writeln!(
                 f,
-                "{}",
                 "You do not seem to be authorized with Signal. Please delete the database and relink the application."
             ),
             ApplicationError::SendFailed(_) => writeln!(
                 f,
-                "{}",
                 "Sending a message failed."
             ),
             ApplicationError::ReceiveFailed(_) => writeln!(
                 f,
-                "{}",
                 "Receiving a message failed."
             ),
             ApplicationError::Presage(e) => writeln!(
                 f,
-                "{}: {}",
-                "presage error: ",
-                e.to_string()
+                "presage error: : {}",
+                e
             ),
             ApplicationError::WebSocketError => writeln!(
                 f,
-                "{}",
                 "The websocket connection to the signal server failed."
             ),
             ApplicationError::WebSocketHandleMessageError(e) => writeln!(
                 f,
-                "{}: {}",
-                "Couldn't handle websocket message.",
+                "Couldn't handle websocket message.: {}",
                 e
             ),
             ApplicationError::RegistrationError(e) => writeln!(
                 f,
-                "{}: {}",
-                "Registration failed.",
+                "Registration failed.: {}",
                 e
             ),
             ApplicationError::InvalidRequest=> writeln!(
                 f,
-                "{}",
                 "Invalid request.",
             ),
             ApplicationError::SledStore(_) => writeln!(
                 f,
-                "{}",
                 "Something unexpected happened with the database. Please retry later."
             ),
             ApplicationError::RegistrationSuccesful => writeln!(
                 f,
-                "{}",
                 "Registration succesful."
             ),
 
@@ -115,9 +103,7 @@ impl From<PresageError> for ApplicationError {
 // convert presage errors to application errors
 impl From<SledStoreError> for ApplicationError {
     fn from(e: SledStoreError) -> Self {
-        match e {
-            _ => ApplicationError::SledStore(e),
-        }
+        ApplicationError::SledStore(e)
     }
 }
 // convert websocket errors to application errors

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -212,224 +212,7 @@ impl Handler {
 
                 let receiver = self.receiver.clone();
                 if let Some(r) = receiver {
-                    let mut r = r.lock().await;
-                    let mut is_closed = false;
-                    while let Some(message) = r.next().await {
-                        match message {
-                            Ok(message) => {
-                                if message.is_close() {
-                                    log::info!("Got close message, exiting");
-                                    is_closed = true;
-                                    break;
-                                } else if message.is_text() {
-                                    let text = message.to_str().unwrap();
-                                    if let Ok::<AxolotlRequest, SerdeError>(axolotl_request) =
-                                        serde_json::from_str(text)
-                                    {
-                                        // Axolotl request
-                                        let request_type: &str = axolotl_request.request.as_str();
-                                        log::info!(
-                                            "Axolotl registration request: {}",
-                                            request_type
-                                        );
-                                        if request_type == "primaryDevice" {
-                                            self.get_phone_number().await;
-                                        } else if request_type == "registerSecondaryDevice" {
-                                            loop {
-                                                log::debug!("Registering secondary device");
-                                                self.create_provisioning_link().await?;
-                                                if self.is_registered.is_some()
-                                                    && self.is_registered.unwrap()
-                                                {
-                                                    log::debug!("Device is already registered");
-                                                    break;
-                                                }
-                                                log::debug!(
-                                                    "Provisioning link created successfully"
-                                                );
-                                                self.handle_provisoning().await;
-                                                log::debug!(
-                                                    "Provisioning link handled successfully"
-                                                );
-                                                self.send_provisioning_link().await;
-                                                log::debug!(
-                                                    "Provisioning link sent successfully to client"
-                                                );
-                                                let error_reciever =
-                                                    self.error_rx.as_mut().unwrap();
-                                                let mut error_reciever =
-                                                    error_reciever.lock().await;
-                                                while let Ok(e) = error_reciever.try_recv() {
-                                                    match e {
-                                                        Some(u) => {
-                                                            log::error!("Error registering secondary device: {}", u);
-                                                            Some(u)
-                                                        }
-                                                        None => {
-                                                            thread::sleep(
-                                                                time::Duration::from_secs(1),
-                                                            );
-                                                            continue;
-                                                        }
-                                                    };
-                                                }
-                                                if error_reciever.try_recv().is_err() {
-                                                    log::debug!("Break out of loop, because error channel is closed");
-                                                    match Handler::check_registration().await {
-                                                        Ok(_) => {
-                                                            self.is_registered = Some(true);
-                                                            break;
-                                                        }
-                                                        Err(e) => {
-                                                            log::debug!(
-                                                                "Error checking registration: {}",
-                                                                e
-                                                            );
-                                                            self.is_registered = Some(false);
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            self.send_registration_confirmation().await;
-                                            log::debug!("Registration confirmation sent and done, now sleeping");
-                                            if let Some(error_opt) = self.receive_error.recv().await
-                                            {
-                                                log::error!(
-                                                    "Got error after linking device2: {}",
-                                                    error_opt
-                                                );
-                                                continue;
-                                            }
-                                        }
-                                        if request_type == "sendCaptchaToken" {
-                                            log::debug!("Got captcha token");
-                                            self.captcha = axolotl_request.data;
-                                            log::debug!("Got captcha token: {:?}", self.captcha);
-                                            log::debug!("Getting phone number");
-                                            self.get_phone_number().await;
-                                        } else if request_type == "requestCode" {
-                                            self.phone_number = match axolotl_request.data {
-                                                Some(data) => {
-                                                    match phonenumber::parse(None, data) {
-                                                        Ok(phone_number) => Some(phone_number),
-                                                        Err(e) => {
-                                                            log::error!(
-                                                                "Error parsing phone number: {}",
-                                                                e
-                                                            );
-                                                            None
-                                                        }
-                                                    }
-                                                }
-                                                None => None,
-                                            };
-                                            if self.phone_number.is_some() {
-                                                log::debug!(
-                                                    "Got phone number: {}",
-                                                    self.phone_number.as_ref().unwrap()
-                                                );
-                                                let (code_tx, code_rx) =
-                                                    mpsc::channel(MESSAGE_BOUND);
-                                                self.get_phone_pin().await;
-                                                match self.get_verification_code(code_rx).await {
-                                                    Ok(_) => log::debug!(
-                                                        "Success sending verification code"
-                                                    ),
-                                                    Err(e) => {
-                                                        log::error!(
-                                                            "Error getting verification code: {}",
-                                                            e
-                                                        );
-                                                        self.get_phone_number().await;
-                                                        break;
-                                                    }
-                                                }
-                                                let code_message: Option<
-                                                    Result<Message, warp::Error>,
-                                                > = r.next().await;
-                                                if let Some(code_message) = code_message {
-                                                    match code_message {
-                                                        Ok(code_message) => {
-                                                            if code_message.is_close() {
-                                                                log::info!(
-                                                                    "Got close message, exiting"
-                                                                );
-                                                                is_closed = true;
-                                                                break;
-                                                            } else if code_message.is_text() {
-                                                                let text =
-                                                                    code_message.to_str().unwrap();
-                                                                if let Ok::<
-                                                                    AxolotlRequest,
-                                                                    SerdeError,
-                                                                >(
-                                                                    axolotl_request
-                                                                ) = serde_json::from_str(text)
-                                                                {
-                                                                    // Axolotl request
-                                                                    let request_type: &str =
-                                                                        axolotl_request
-                                                                            .request
-                                                                            .as_str();
-                                                                    log::info!(
-                                                                        "Axolotl registration request code message: {}",
-                                                                        request_type
-                                                                    );
-                                                                    if request_type == "sendCode" {
-                                                                        let code =
-                                                                            axolotl_request.data;
-                                                                        if code.is_some() {
-                                                                            let code =
-                                                                                code.unwrap();
-                                                                            log::info!(
-                                                                                "Got code: {}",
-                                                                                code
-                                                                            );
-                                                                            match code_tx
-                                                                                .send(code.into_boxed_str())
-                                                                                .await
-                                                                            {
-                                                                                Ok(_) => (),
-                                                                                Err(e) => {
-                                                                                    log::error!("Error sending code to registration manager: {}", e);
-                                                                                    break;
-                                                                                }
-                                                                            };
-                                                                        } else {
-                                                                            log::error!("No valid code provided");
-                                                                            self.get_phone_pin()
-                                                                                .await;
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                        Err(e) => {
-                                                            log::error!(
-                                                                "Error getting message: {}",
-                                                                e
-                                                            );
-                                                            break;
-                                                        }
-                                                    }
-                                                }
-                                            } else {
-                                                log::error!("No valid phone number provided");
-                                                self.get_phone_number().await;
-                                            }
-                                        }
-                                    }
-                                    log::info!("Got text message: {}", text);
-                                }
-                            }
-                            Err(e) => {
-                                log::error!("Error getting message: {}", e);
-                                break;
-                            }
-                        }
-                    }
-                    if is_closed {
-                        log::info!("Got close message, exiting2");
+                    if !self.register(r).await? {
                         break;
                     }
                 }
@@ -464,10 +247,199 @@ impl Handler {
                 self.handle_receiving_messages().await;
             }
         }
+
         log::debug!("Exiting loop");
         Err(ApplicationError::WebSocketHandleMessageError(
             "Too many errors, exiting".to_string(),
         ))
+    }
+
+    async fn register(
+        &mut self,
+        r: Arc<Mutex<SplitStream<WebSocket>>>,
+    ) -> Result<bool, ApplicationError> {
+        let mut r = r.lock().await;
+        let mut is_closed = false;
+        while let Some(message) = r.next().await {
+            match message {
+                Ok(message) => {
+                    if message.is_close() {
+                        log::info!("Got close message, exiting");
+                        is_closed = true;
+                        break;
+                    } else if message.is_text() {
+                        let text = message.to_str().unwrap();
+                        if let Ok::<AxolotlRequest, SerdeError>(axolotl_request) =
+                            serde_json::from_str(text)
+                        {
+                            // Axolotl request
+                            let request_type: &str = axolotl_request.request.as_str();
+                            log::info!("Axolotl registration request: {}", request_type);
+                            if request_type == "primaryDevice" {
+                                self.get_phone_number().await;
+                            } else if request_type == "registerSecondaryDevice" {
+                                loop {
+                                    log::debug!("Registering secondary device");
+                                    self.create_provisioning_link().await?;
+                                    if self.is_registered.is_some() && self.is_registered.unwrap() {
+                                        log::debug!("Device is already registered");
+                                        break;
+                                    }
+                                    log::debug!("Provisioning link created successfully");
+                                    self.handle_provisoning().await;
+                                    log::debug!("Provisioning link handled successfully");
+                                    self.send_provisioning_link().await;
+                                    log::debug!("Provisioning link sent successfully to client");
+                                    let error_reciever = self.error_rx.as_mut().unwrap();
+                                    let mut error_reciever = error_reciever.lock().await;
+                                    while let Ok(e) = error_reciever.try_recv() {
+                                        match e {
+                                            Some(u) => {
+                                                log::error!(
+                                                    "Error registering secondary device: {}",
+                                                    u
+                                                );
+                                                Some(u)
+                                            }
+                                            None => {
+                                                thread::sleep(time::Duration::from_secs(1));
+                                                continue;
+                                            }
+                                        };
+                                    }
+                                    if error_reciever.try_recv().is_err() {
+                                        log::debug!(
+                                            "Break out of loop, because error channel is closed"
+                                        );
+                                        match Handler::check_registration().await {
+                                            Ok(_) => {
+                                                self.is_registered = Some(true);
+                                                break;
+                                            }
+                                            Err(e) => {
+                                                log::debug!("Error checking registration: {}", e);
+                                                self.is_registered = Some(false);
+                                            }
+                                        }
+                                    }
+                                }
+                                self.send_registration_confirmation().await;
+                                log::debug!(
+                                    "Registration confirmation sent and done, now sleeping"
+                                );
+                                if let Some(error_opt) = self.receive_error.recv().await {
+                                    log::error!("Got error after linking device2: {}", error_opt);
+                                    continue;
+                                }
+                            }
+                            if request_type == "sendCaptchaToken" {
+                                log::debug!("Got captcha token");
+                                self.captcha = axolotl_request.data;
+                                log::debug!("Got captcha token: {:?}", self.captcha);
+                                log::debug!("Getting phone number");
+                                self.get_phone_number().await;
+                            } else if request_type == "requestCode" {
+                                self.phone_number = match axolotl_request.data {
+                                    Some(data) => match phonenumber::parse(None, data) {
+                                        Ok(phone_number) => Some(phone_number),
+                                        Err(e) => {
+                                            log::error!("Error parsing phone number: {}", e);
+                                            None
+                                        }
+                                    },
+                                    None => None,
+                                };
+                                if self.phone_number.is_some() {
+                                    log::debug!(
+                                        "Got phone number: {}",
+                                        self.phone_number.as_ref().unwrap()
+                                    );
+                                    let (code_tx, code_rx) = mpsc::channel(MESSAGE_BOUND);
+                                    self.get_phone_pin().await;
+                                    match self.get_verification_code(code_rx).await {
+                                        Ok(_) => {
+                                            log::debug!("Success sending verification code")
+                                        }
+                                        Err(e) => {
+                                            log::error!("Error getting verification code: {}", e);
+                                            self.get_phone_number().await;
+                                            break;
+                                        }
+                                    }
+                                    let code_message: Option<Result<Message, warp::Error>> =
+                                        r.next().await;
+                                    if let Some(code_message) = code_message {
+                                        match code_message {
+                                            Ok(code_message) => {
+                                                if code_message.is_close() {
+                                                    log::info!("Got close message, exiting");
+                                                    is_closed = true;
+                                                    break;
+                                                } else if code_message.is_text() {
+                                                    let text = code_message.to_str().unwrap();
+                                                    if let Ok::<AxolotlRequest, SerdeError>(
+                                                        axolotl_request,
+                                                    ) = serde_json::from_str(text)
+                                                    {
+                                                        // Axolotl request
+                                                        let request_type: &str =
+                                                            axolotl_request.request.as_str();
+                                                        log::info!(
+                                                                        "Axolotl registration request code message: {}",
+                                                                        request_type
+                                                                    );
+                                                        if request_type == "sendCode" {
+                                                            let code = axolotl_request.data;
+                                                            if code.is_some() {
+                                                                let code = code.unwrap();
+                                                                log::info!("Got code: {}", code);
+                                                                match code_tx
+                                                                    .send(code.into_boxed_str())
+                                                                    .await
+                                                                {
+                                                                    Ok(_) => (),
+                                                                    Err(e) => {
+                                                                        log::error!("Error sending code to registration manager: {}", e);
+                                                                        break;
+                                                                    }
+                                                                };
+                                                            } else {
+                                                                log::error!(
+                                                                    "No valid code provided"
+                                                                );
+                                                                self.get_phone_pin().await;
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            Err(e) => {
+                                                log::error!("Error getting message: {}", e);
+                                                break;
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    log::error!("No valid phone number provided");
+                                    self.get_phone_number().await;
+                                }
+                            }
+                        }
+                        log::info!("Got text message: {}", text);
+                    }
+                }
+                Err(e) => {
+                    log::error!("Error getting message: {}", e);
+                    break;
+                }
+            }
+        }
+        if is_closed {
+            log::info!("Got close message, exiting2");
+            return Ok(false);
+        }
+
+        Ok(true)
     }
 
     async fn check_registration() -> Result<(), ApplicationError> {
@@ -783,6 +755,7 @@ impl Handler {
             self.provisioning_link = url;
         }
     }
+
     async fn start_registration(&self) -> Result<(), ApplicationError> {
         log::info!("Starting registration");
         // wait for a sender to be available

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -62,6 +62,7 @@ pub struct Handler {
     pub phone_number: Option<PhoneNumber>,
     pub registration_manager: Option<Arc<Mutex<Manager<SledStore, Confirmation>>>>,
 }
+
 impl Handler {
     pub async fn new() -> Result<Self, ApplicationError> {
         log::info!("Setting up the handler");
@@ -304,136 +305,146 @@ impl Handler {
             // Axolotl request
             let request_type: &str = axolotl_request.request.as_str();
             log::info!("Axolotl registration request: {}", request_type);
-            if request_type == "primaryDevice" {
-                self.get_phone_number().await;
-            } else if request_type == "registerSecondaryDevice" {
-                loop {
-                    log::debug!("Registering secondary device");
-                    self.create_provisioning_link().await?;
-                    if self.is_registered.is_some() && self.is_registered.unwrap() {
-                        log::debug!("Device is already registered");
-                        break;
-                    }
-                    log::debug!("Provisioning link created successfully");
-                    self.handle_provisoning().await;
-                    log::debug!("Provisioning link handled successfully");
-                    self.send_provisioning_link().await;
-                    log::debug!("Provisioning link sent successfully to client");
-                    let error_reciever = self.error_rx.as_mut().unwrap();
-                    let mut error_reciever = error_reciever.lock().await;
-                    while let Ok(e) = error_reciever.try_recv() {
-                        match e {
-                            Some(u) => {
-                                log::error!("Error registering secondary device: {}", u);
-                                Some(u)
+            match request_type {
+                "primaryDevice" => {
+                    self.get_phone_number().await;
+                }
+                "registerSecondaryDevice" => {
+                    loop {
+                        log::debug!("Registering secondary device");
+                        self.create_provisioning_link().await?;
+                        if self.is_registered.is_some() && self.is_registered.unwrap() {
+                            log::debug!("Device is already registered");
+                            break;
+                        }
+                        log::debug!("Provisioning link created successfully");
+                        self.handle_provisoning().await;
+                        log::debug!("Provisioning link handled successfully");
+                        self.send_provisioning_link().await;
+                        log::debug!("Provisioning link sent successfully to client");
+                        let error_reciever = self.error_rx.as_mut().unwrap();
+                        let mut error_reciever = error_reciever.lock().await;
+                        while let Ok(e) = error_reciever.try_recv() {
+                            match e {
+                                Some(u) => {
+                                    log::error!("Error registering secondary device: {}", u);
+                                    Some(u)
+                                }
+                                None => {
+                                    thread::sleep(time::Duration::from_secs(1));
+                                    continue;
+                                }
+                            };
+                        }
+                        if error_reciever.try_recv().is_err() {
+                            log::debug!("Break out of loop, because error channel is closed");
+                            match Handler::check_registration().await {
+                                Ok(_) => {
+                                    self.is_registered = Some(true);
+                                    break;
+                                }
+                                Err(e) => {
+                                    log::debug!("Error checking registration: {}", e);
+                                    self.is_registered = Some(false);
+                                }
                             }
-                            None => {
-                                thread::sleep(time::Duration::from_secs(1));
-                                continue;
-                            }
-                        };
+                        }
                     }
-                    if error_reciever.try_recv().is_err() {
-                        log::debug!("Break out of loop, because error channel is closed");
-                        match Handler::check_registration().await {
+                    self.send_registration_confirmation().await;
+                    log::debug!("Registration confirmation sent and done, now sleeping");
+                    if let Some(error_opt) = self.receive_error.recv().await {
+                        log::error!("Got error after linking device2: {}", error_opt);
+                        return Ok(true);
+                    }
+                }
+                "sendCaptchaToken" => {
+                    log::debug!("Got captcha token");
+                    self.captcha = axolotl_request.data;
+                    log::debug!("Got captcha token: {:?}", self.captcha);
+                    log::debug!("Getting phone number");
+                    self.get_phone_number().await;
+                }
+                "requestCode" => {
+                    self.phone_number = match axolotl_request.data {
+                        Some(data) => match phonenumber::parse(None, data) {
+                            Ok(phone_number) => Some(phone_number),
+                            Err(e) => {
+                                log::error!("Error parsing phone number: {}", e);
+                                None
+                            }
+                        },
+                        None => None,
+                    };
+                    if self.phone_number.is_some() {
+                        log::debug!("Got phone number: {}", self.phone_number.as_ref().unwrap());
+                        let (code_tx, code_rx) = mpsc::channel(MESSAGE_BOUND);
+                        self.get_phone_pin().await;
+                        match self.get_verification_code(code_rx).await {
                             Ok(_) => {
-                                self.is_registered = Some(true);
-                                break;
+                                log::debug!("Success sending verification code")
                             }
                             Err(e) => {
-                                log::debug!("Error checking registration: {}", e);
-                                self.is_registered = Some(false);
+                                log::error!("Error getting verification code: {}", e);
+                                self.get_phone_number().await;
+                                return Ok(false);
                             }
                         }
-                    }
-                }
-                self.send_registration_confirmation().await;
-                log::debug!("Registration confirmation sent and done, now sleeping");
-                if let Some(error_opt) = self.receive_error.recv().await {
-                    log::error!("Got error after linking device2: {}", error_opt);
-                    return Ok(true);
-                }
-            }
-            if request_type == "sendCaptchaToken" {
-                log::debug!("Got captcha token");
-                self.captcha = axolotl_request.data;
-                log::debug!("Got captcha token: {:?}", self.captcha);
-                log::debug!("Getting phone number");
-                self.get_phone_number().await;
-            } else if request_type == "requestCode" {
-                self.phone_number = match axolotl_request.data {
-                    Some(data) => match phonenumber::parse(None, data) {
-                        Ok(phone_number) => Some(phone_number),
-                        Err(e) => {
-                            log::error!("Error parsing phone number: {}", e);
-                            None
-                        }
-                    },
-                    None => None,
-                };
-                if self.phone_number.is_some() {
-                    log::debug!("Got phone number: {}", self.phone_number.as_ref().unwrap());
-                    let (code_tx, code_rx) = mpsc::channel(MESSAGE_BOUND);
-                    self.get_phone_pin().await;
-                    match self.get_verification_code(code_rx).await {
-                        Ok(_) => {
-                            log::debug!("Success sending verification code")
-                        }
-                        Err(e) => {
-                            log::error!("Error getting verification code: {}", e);
-                            self.get_phone_number().await;
-                            return Ok(false);
-                        }
-                    }
-                    let code_message: Option<Result<Message, warp::Error>> =
-                        r.lock().await.next().await;
-                    if let Some(code_message) = code_message {
-                        match code_message {
-                            Ok(code_message) => {
-                                if code_message.is_close() {
-                                    log::info!("Got close message, exiting");
-                                    *is_closed = true;
-                                    return Ok(false);
-                                } else if code_message.is_text() {
-                                    let text = code_message.to_str().unwrap();
-                                    if let Ok::<AxolotlRequest, SerdeError>(axolotl_request) =
-                                        serde_json::from_str(text)
-                                    {
-                                        // Axolotl request
-                                        let request_type: &str = axolotl_request.request.as_str();
-                                        log::info!(
-                                            "Axolotl registration request code message: {}",
-                                            request_type
-                                        );
-                                        if request_type == "sendCode" {
-                                            let code = axolotl_request.data;
-                                            if code.is_some() {
-                                                let code = code.unwrap();
-                                                log::info!("Got code: {}", code);
-                                                match code_tx.send(code.into_boxed_str()).await {
-                                                    Ok(_) => (),
-                                                    Err(e) => {
-                                                        log::error!("Error sending code to registration manager: {}", e);
-                                                        return Ok(false);
-                                                    }
-                                                };
-                                            } else {
-                                                log::error!("No valid code provided");
-                                                self.get_phone_pin().await;
+                        let code_message: Option<Result<Message, warp::Error>> =
+                            r.lock().await.next().await;
+                        if let Some(code_message) = code_message {
+                            match code_message {
+                                Ok(code_message) => {
+                                    if code_message.is_close() {
+                                        log::info!("Got close message, exiting");
+                                        *is_closed = true;
+                                        return Ok(false);
+                                    } else if code_message.is_text() {
+                                        let text = code_message.to_str().unwrap();
+                                        if let Ok::<AxolotlRequest, SerdeError>(axolotl_request) =
+                                            serde_json::from_str(text)
+                                        {
+                                            // Axolotl request
+                                            let request_type: &str =
+                                                axolotl_request.request.as_str();
+                                            log::info!(
+                                                "Axolotl registration request code message: {}",
+                                                request_type
+                                            );
+                                            if request_type == "sendCode" {
+                                                let code = axolotl_request.data;
+                                                if code.is_some() {
+                                                    let code = code.unwrap();
+                                                    log::info!("Got code: {}", code);
+                                                    match code_tx.send(code.into_boxed_str()).await
+                                                    {
+                                                        Ok(_) => (),
+                                                        Err(e) => {
+                                                            log::error!("Error sending code to registration manager: {}", e);
+                                                            return Ok(false);
+                                                        }
+                                                    };
+                                                } else {
+                                                    log::error!("No valid code provided");
+                                                    self.get_phone_pin().await;
+                                                }
                                             }
                                         }
                                     }
                                 }
-                            }
-                            Err(e) => {
-                                log::error!("Error getting message: {}", e);
-                                return Ok(false);
+                                Err(e) => {
+                                    log::error!("Error getting message: {}", e);
+                                    return Ok(false);
+                                }
                             }
                         }
+                    } else {
+                        log::error!("No valid phone number provided");
+                        self.get_phone_number().await;
                     }
-                } else {
-                    log::error!("No valid phone number provided");
-                    self.get_phone_number().await;
+                }
+                unknown => {
+                    log::error!("Unknown message type: {unknown}");
+                    return Ok(false);
                 }
             }
         }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -96,8 +96,8 @@ impl AttachmentMessage {
     pub fn new(ctype: &str, filename: &str) -> Self {
         // Use the first part of the MIME type
         // image/png becomes image
-        let content_type = if ctype.contains("/") {
-            ctype.split("/").collect::<Vec<&str>>()[0].to_string()
+        let content_type = if ctype.contains('/') {
+            ctype.split('/').collect::<Vec<&str>>()[0].to_string()
         } else {
             ctype.to_string()
         };
@@ -159,7 +159,7 @@ impl AxolotlMessage {
         };
         if let ContentBody::SynchronizeMessage(data) = body {
             if data.sent.is_some() && data.sent.clone().unwrap().message.is_some() {
-                let m = data.sent.clone().unwrap().message.clone().unwrap();
+                let m = data.sent.clone().unwrap().message.unwrap();
                 if !m.attachments.is_empty() {
                     for attachment in &m.attachments {
                         if let Some(AttachmentIdentifier::CdnId(id)) =
@@ -182,7 +182,7 @@ impl AxolotlMessage {
         let data_message = match body {
             ContentBody::DataMessage(data) => {
                 if data.reaction.is_some() {
-                    data.reaction.clone().unwrap().emoji.clone()
+                    data.reaction.clone().unwrap().emoji
                 } else {
                     data.body.clone()
                 }
@@ -190,8 +190,8 @@ impl AxolotlMessage {
             ContentBody::SynchronizeMessage(data) => {
                 is_outgoing = true;
                 if data.sent.is_some() && data.sent.clone().unwrap().message.is_some() {
-                    let m = data.sent.clone().unwrap().message.clone().unwrap();
-                    m.body.clone()
+                    let m = data.sent.clone().unwrap().message.unwrap();
+                    m.body
                 } else {
                     Some("SyncMessage".to_string())
                 }
@@ -205,7 +205,7 @@ impl AxolotlMessage {
             message_type,
             message: data_message,
             timestamp: Some(timestamp),
-            attachments: attachments,
+            attachments,
             is_outgoing,
             thread_id: None,
             is_sent: true, // TODO
@@ -250,8 +250,8 @@ impl AxolotlMessage {
         let data_message = match &body {
             ContentBody::DataMessage(data) => {
                 if data.reaction.is_some() {
-                    data.reaction.clone().unwrap().emoji.clone()
-                } else if data.attachments.len() > 0 {
+                    data.reaction.clone().unwrap().emoji
+                } else if !data.attachments.is_empty() {
                     if data.body.is_some() {
                         Some(format!(
                             "Unsuported attachment. {}",
@@ -267,10 +267,10 @@ impl AxolotlMessage {
             ContentBody::SynchronizeMessage(data) => {
                 is_outgoing = true;
                 if data.sent.is_some() && data.sent.clone().unwrap().message.is_some() {
-                    let m = data.sent.clone().unwrap().message.clone().unwrap();
+                    let m = data.sent.clone().unwrap().message.unwrap();
                     if m.reaction.is_some() {
-                        m.reaction.clone().unwrap().emoji.clone()
-                    } else if m.attachments.len() > 0 {
+                        m.reaction.unwrap().emoji
+                    } else if !m.attachments.is_empty() {
                         for attachment in &m.attachments {
                             if let Some(AttachmentIdentifier::CdnId(id)) =
                                 attachment.attachment_identifier
@@ -289,13 +289,13 @@ impl AxolotlMessage {
                         if m.body.is_some() {
                             Some(format!(
                                 "Unsuported attachment. {}",
-                                m.body.clone().unwrap()
+                                m.body.unwrap()
                             ))
                         } else {
                             Some("Unsuported attachment.".to_string())
                         }
                     } else {
-                        m.body.clone()
+                        m.body
                     }
                 } else {
                     Some("SyncMessage".to_string())
@@ -304,9 +304,9 @@ impl AxolotlMessage {
             _ => None,
         };
         let timestamp: Option<u64> = match body {
-            ContentBody::DataMessage(m) => m.timestamp.clone(),
+            ContentBody::DataMessage(m) => m.timestamp,
             ContentBody::SynchronizeMessage(m) => match m.sent {
-                Some(s) => s.timestamp.clone(),
+                Some(s) => s.timestamp,
                 None => None,
             },
             _ => None,
@@ -315,10 +315,10 @@ impl AxolotlMessage {
             sender: None,
             message_type,
             message: data_message,
-            timestamp: timestamp,
+            timestamp,
             is_outgoing,
             thread_id: None,
-            attachments: attachments,
+            attachments,
             is_sent: true, // TODO
         }
     }
@@ -345,8 +345,8 @@ impl AxolotlMessage {
         };
 
         let data_message = if data.reaction.is_some() {
-            data.reaction.clone().unwrap().emoji.clone()
-        } else if data.attachments.len() > 0 {
+            data.reaction.clone().unwrap().emoji
+        } else if !data.attachments.is_empty() {
             if data.body.is_some() {
                 Some(format!(
                     "Unsuported attachment. {}",
@@ -366,7 +366,7 @@ impl AxolotlMessage {
             timestamp: Some(timestamp),
             is_outgoing,
             thread_id: None,
-            attachments: attachments,
+            attachments,
             is_sent: true, // TODO
         }
     }


### PR DESCRIPTION
This PR separates the registration code from a 300-lines function with indentations up to 21 levels deep into several functions in order to improve readability and maintainability. In addition, most linter remarks (cargo clippy) have been fixed and the number of `unwrap()`s reduced (most could be avoided by simplifying the code).

Please check thoroughly that the change does not break anything.