### PR TITLE
Relieve backend from the need of being `Send`

### DIFF
--- a/axolotl-web/src/pages/Verification.vue
+++ b/axolotl-web/src/pages/Verification.vue
@@ -50,9 +50,12 @@ export default {
       this.code = code
     },
     sendCode() {
+      console.log("send code", this.code)
       if (this.code.length === 6) {
         this.$store.dispatch("sendCode", this.code);
         this.inProgress = true;
+      } else {
+        console.error("code not 6 digits")
       }
     },
     sendPin() {

--- a/axolotl-web/src/store/store.js
+++ b/axolotl-web/src/store/store.js
@@ -4,6 +4,7 @@ import { validateUUID } from "@/helpers/uuidCheck";
 import app from "../main";
 
 function socketSend(message) {
+  console.log("socketSend", message);
   app.config.globalProperties.$socket.send(JSON.stringify(message));
 }
 
@@ -808,12 +809,17 @@ export default createStore({
       }
     },
     sendCode(state, code) {
+      console.log("store: sendCode", code);
       if (this.state.socket.isConnected) {
         const message = {
           request: "sendCode",
           data: code,
         };
+        console.log("store: sendCode", message);
         socketSend(message);
+      } else {
+        console.error("socket not connected");
+        // reconnect socket
       }
     },
     setUsername(state, username) {

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,10 +1,11 @@
 clickable_minimum_required: 7.10.0
 
 builder: rust
-rust_channel: 1.66.1
+rust_channel: 1.71.1
 env_vars:
   CC: ""
   CXX: ""
+  PKG_CONFIG_ALLOW_CROSS: "1"
 prebuild: 
   - mkdir -p ${BUILD_DIR}/axolotl-web 
   - cp ${SRC_DIR}/axolotl-web/dist ${BUILD_DIR}/axolotl-web/ -R
@@ -14,8 +15,6 @@ dependencies_host:
   
 dependencies_target:
   - libdbus-1-dev
-env_vars:
-  PKG_CONFIG_ALLOW_CROSS: "1"
 
 build_args: --features ut 
 kill: axolotl

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -527,7 +527,7 @@ impl Handler {
         let (send_error, receive_error) = mpsc::channel(MESSAGE_BOUND);
         self.receive_error = receive_error;
         log::debug!("Creating runtime");
-        tokio::task::spawn(async move {
+        tokio::task::spawn_local(async move {
             log::debug!("Spawning manager thread");
             ManagerThread::new(
                 config_store.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ mod tauri {
 "#;
 
     pub async fn start_tauri() {
-        let t = tauri::Builder::default().setup(|app| {
+        let t = tauri::Builder::default().any_thread().setup(|app| {
             tauri::WindowBuilder::new(app, "label", tauri::WindowUrl::App("index.html".into()))
                 .initialization_script(INIT_SCRIPT)
                 .title("Axolotl")

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ mod ut {
         tokio::task::spawn_blocking(|| {
             Command::new("qmlscene")
                 .arg("--scaling")
-                .arg("--webEngineArgs ")
+                .arg("--webEngineArgs")
                 .arg("--remote-debugging-port")
                 .arg("ut/MainUt.qml")
                 .stdout(Stdio::piped())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use axolotl::handlers::get_app_dir;
-use std::{process::exit, sync::Arc};
+use std::process::exit;
 
 use axolotl::handlers::Handler;
-use tokio::sync::Mutex;
-use warp::{Filter, Rejection, Reply};
+use tokio::{sync::mpsc, task::JoinHandle};
+use warp::{ws::WebSocket, Filter, Rejection, Reply};
 
 use clap::Parser;
 
@@ -30,21 +30,28 @@ async fn main() {
         .init();
     let args = Args::parse();
 
+    let ui_handle = start_ui(args.mode).await;
+    run_backend().await;
+    ui_handle.await.unwrap();
+}
+
+async fn run_backend() {
+    let (request_tx, request_rx) = mpsc::channel(1);
     let server_task = tokio::spawn(async {
-        let handler = Handler::new().await.unwrap_or_else(|e| {
-            log::error!("Error while starting the server: {}", e);
-            exit(1);
-        });
-        log::info!("Axolotl handler started");
-        start_websocket(Arc::new(Mutex::new(handler))).await;
+        run_websocket(request_tx).await;
     });
 
-    start_ui(args.mode).await;
+    let backend = Handler::new().await.unwrap_or_else(|e| {
+        log::error!("Error while starting the backend: {}", e);
+        exit(1);
+    });
+    log::info!("Axolotl backend started");
 
+    backend.run(request_rx).await.unwrap();
     server_task.await.unwrap();
 }
 
-async fn start_websocket(handler: Arc<Mutex<Handler>>) {
+async fn run_websocket(handler: mpsc::Sender<WebSocket>) {
     log::info!("Starting the websocket server");
 
     let axolotl_ws_route = warp::path("ws")
@@ -67,31 +74,32 @@ async fn start_websocket(handler: Arc<Mutex<Handler>>) {
 
 pub async fn handle_ws_client(
     websocket: warp::ws::Ws,
-    handler: Arc<Mutex<Handler>>,
+    handler: mpsc::Sender<WebSocket>,
 ) -> Result<impl Reply, Rejection> {
     Ok(websocket.on_upgrade(move |websocket| async move {
         log::debug!("New websocket connection");
-        handler.lock().await.handle_ws_client(websocket).await;
-        log::debug!("websocket connection was closed");
+        let _ = handler.send(websocket).await;
     }))
 }
 
-async fn start_ui(mode: Mode) {
-    match mode {
-        #[cfg(feature = "tauri")]
-        Mode::Tauri => {
-            log::info!("Starting the tauri client");
-            tauri::start_tauri().await;
+async fn start_ui(mode: Mode) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        match mode {
+            #[cfg(feature = "tauri")]
+            Mode::Tauri => {
+                log::info!("Starting the tauri client");
+                tauri::start_tauri().await;
+            }
+            #[cfg(feature = "ut")]
+            Mode::UbuntuTouch => {
+                log::info!("Starting the Ubuntu Touch client");
+                ut::start_ut().await;
+            }
+            Mode::Daemon => {
+                log::info!("Running headless");
+            }
         }
-        #[cfg(feature = "ut")]
-        Mode::UbuntuTouch => {
-            log::info!("Starting the Ubuntu Touch client");
-            ut::start_ut().await;
-        }
-        Mode::Daemon => {
-            log::info!("Running headless");
-        }
-    }
+    })
 }
 
 #[cfg(feature = "tauri")]
@@ -154,16 +162,20 @@ mod ut {
             let route = warp::fs::dir("./axolotl-web/dist");
             warp::serve(route).run(([127, 0, 0, 1], 9081)).await;
         });
-        Command::new("qmlscene")
-            .arg("--scaling")
-            .arg("--webEngineArgs ")
-            .arg("--remote-debugging-port")
-            .arg("ut/MainUt.qml")
-            .stdout(Stdio::piped())
-            .spawn()
-            .expect("GUI failed to start")
-            .wait()
-            .unwrap();
+        tokio::task::spawn_blocking(|| {
+            Command::new("qmlscene")
+                .arg("--scaling")
+                .arg("--webEngineArgs ")
+                .arg("--remote-debugging-port")
+                .arg("ut/MainUt.qml")
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("GUI failed to start")
+                .wait()
+                .unwrap()
+        })
+        .await
+        .unwrap();
 
         exit(0);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use axolotl::handlers::get_app_dir;
+use axolotl::handlers::{create_and_run_backend, get_app_dir};
 use std::process::exit;
 
 use axolotl::handlers::Handler;
@@ -41,13 +41,7 @@ async fn run_backend() {
         run_websocket(request_tx).await;
     });
 
-    let backend = Handler::new().await.unwrap_or_else(|e| {
-        log::error!("Error while starting the backend: {}", e);
-        exit(1);
-    });
-    log::info!("Axolotl backend started");
-
-    backend.run(request_rx).await.unwrap();
+    create_and_run_backend(request_rx).await.unwrap();
     server_task.await.unwrap();
 }
 


### PR DESCRIPTION
This PR introduces a channel between warp websocket handlers and the backend to relieve the backend from the need of being `Send`. This allows for some code simplifications like removing Mutex wrappers and creation of multiple tokio Runtimes.