### PR TITLE
WIP: Avoid npm nodejs version conflict in Clickable images

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -24,6 +24,11 @@ jobs:
         run: |
           mkdir -p $GITHUB_WORKSPACE/build/all/axolotlweb/install/axolotl-web/dist
           cp -rf build-artifacts/axolotl-web/* $GITHUB_WORKSPACE/build/all/axolotlweb/install/axolotl-web/dist
+          # workaround for https://gitlab.com/clickable/clickable/-/issues/422
+          mkdir -p $GITHUB_WORKSPACE/build/{arm-linux-gnueabihf,aarch64-linux-gnu,x86_64-linux-gnu}/
+          ln -s ../all/axolotlweb $GITHUB_WORKSPACE/build/arm-linux-gnueabihf/axolotlweb
+          ln -s ../all/axolotlweb $GITHUB_WORKSPACE/build/aarch64-linux-gnu/axolotlweb
+          ln -s ../all/axolotlweb $GITHUB_WORKSPACE/build/x86_64-linux-gnu/axolotlweb
 
       - name: Build click (${{ matrix.arch }})
         # workaround https://github.com/actions/runner/issues/1479#issuecomment-969306629

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Put axolotl web in place
         run: |
-          mkdir $GITHUB_WORKSPACE/axolotl-web/dist
-          cp -rf build-artifacts/axolotl-web/* $GITHUB_WORKSPACE/axolotl-web/dist
+          mkdir -p $GITHUB_WORKSPACE/build/all/axolotlweb/install/axolotl-web/dist
+          cp -rf build-artifacts/axolotl-web/* $GITHUB_WORKSPACE/build/all/axolotlweb/install/axolotl-web/dist
 
       - name: Build click (${{ matrix.arch }})
         # workaround https://github.com/actions/runner/issues/1479#issuecomment-969306629

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -35,7 +35,7 @@ libraries:
         - mkdir -p /etc/apt/keyrings
         - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
         - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-        - apt-get update && apt-get install -y nodejs npm
+        - apt-get update && apt-get install -y nodejs
         - echo "NODE Version:" && node --version
         - echo "NPM Version:" && npm --version
 


### PR DESCRIPTION
With `npm` in the install command, I get:

```
The following packages have unmet dependencies:
 nodejs : Conflicts: npm
```

Without `npm` in the install command, `npm` get still installed in the image and everything seems to work fine, at least locally.