### PR TITLE
Make manifest more consistent

### DIFF
--- a/flatpak/org.nanuc.Axolotl.yml
+++ b/flatpak/org.nanuc.Axolotl.yml
@@ -59,16 +59,14 @@ modules:
         # Cargo offline mode
         CARGO_NET_OFFLINE: "true"
     build-commands:
-      # Install the packages from the offline cache
-      - yarn --cwd=axolotl-web install
-
       # Build axolotl-web
-      - yarn --cwd=axolotl-web run build
+      - make build-dependencies-axolotl-web
+      - make build-axolotl-web
 
       # Build axolotl
-      - cargo --offline fetch --verbose
-      - cargo --offline build --features tauri --release --verbose
-      - install -Dm755 ./target/release/axolotl -t /app/bin/
+      - cargo fetch --verbose
+      - cargo build --features tauri --release --verbose
+      - install -Dm 755 target/release/axolotl -t ${FLATPAK_DEST}/bin/
 
       # Install metadata files
       - install -Dm 644 flatpak/org.nanuc.Axolotl.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png


### PR DESCRIPTION
Make the Flatpak manifest as equal as possible to the Flatpak one in flathub/org.nanuc.Axolotl#18.

It also fixes the `Makefile` which broke with the migration from `npm` to `yarn`.