### PR TITLE
[flatpak] Implement the local setup like Flathub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,10 @@ install-flatpak:
 	$(FLATPAK_BUILDER) flatpak/build --force-clean --user --install flatpak/org.nanuc.Axolotl.yml
 
 debug-flatpak:
-	$(FLATPAK_BUILDER) flatpak/build --run --verbose flatpak/org.nanuc.Axolotl.yml sh
+	$(FLATPAK_BUILDER) --run --verbose flatpak/build flatpak/org.nanuc.Axolotl.yml sh
+
+debug-installed-flatpak:
+	$(FLATPAK) run --command=sh --devel org.nanuc.Axolotl
 
 uninstall-flatpak:
 	$(FLATPAK) uninstall org.nanuc.Axolotl

--- a/flatpak/org.nanuc.Axolotl.yml
+++ b/flatpak/org.nanuc.Axolotl.yml
@@ -5,7 +5,7 @@ sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node18
   - org.freedesktop.Sdk.Extension.rust-stable
-command: axolotl
+command: run.sh
 finish-args:
   # See https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html
   # Write access for the user download folder (to save media)
@@ -44,7 +44,7 @@ modules:
       - /lib/plugins
     sources:
       - type: git
-        url: https://github.com/protocolbuffers/protobuf.git
+        url: https://github.com/protocolbuffers/protobuf
         tag: v25.2
         commit: a9b006bddd52e289029f16aa77b77e8e0033d9ee
 
@@ -75,8 +75,9 @@ modules:
       - install -Dm 644 flatpak/org.nanuc.Axolotl.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
       - install -Dm 644 flatpak/org.nanuc.Axolotl.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
     sources:
-      - type: dir
-        path: ..
+      - type: git
+        url: https://github.com/nanu-c/axolotl
+        branch: main
       # Generated via flatpak-node-generator
       - node-sources.json
       # Generated via flatpak-cargo-generator
@@ -88,3 +89,13 @@ modules:
           --install.offline true
           --run.offline true
         dest-filename: .yarnrc
+
+  - name: run
+    buildsystem: simple
+    build-commands:
+      - install -Dm 755 run.sh ${FLATPAK_DEST}/bin/run.sh
+    sources:
+      - type: script
+        dest-filename: run.sh
+        commands:
+          - axolotl --mode tauri


### PR DESCRIPTION
As we already use offline dependencies, set up the whole thing as fully detatched from the local codebase, based off the main branch.

Lastly, allow starting the app per `flatpak run org.nanuc.Axolotl`, like before, without passing any further configuration.
This is in my view more beginner friendly, as else one is facing a prompt of having to choose a mode.

Note that the axolotl binary is still available, the desktop file works just like it did before.

```
[📦 org.nanuc.Axolotl bin]$ pwd
/app/bin
[📦 org.nanuc.Axolotl bin]$ ls -la
total 24192
drwxr-xr-x. 1 olof olof       26 Jan  1  1970 .
drwxr-xr-x. 1 olof olof       70 Mar  1 21:30 ..
-rwxr-xr-x. 3 olof olof 24767984 Jan  1  1970 axolotl
-rwxr-xr-x. 3 olof olof       31 Jan  1  1970 run.sh
[📦 org.nanuc.Axolotl bin]$ 
```

