### PR TITLE
[maintenance] Remove bundler.json

### DIFF
--- a/bundler.json
+++ b/bundler.json
@@ -1,8 +1,0 @@
-{
-  "app_name": "axolotl-electron-bundle",
-  "icon_path_darwin": "axolotl-web/public/axolotl.png",
-  "icon_path_linux": "axolotl-web/public/axolotl.png",
-  "version_electron": "21.0.1",
-  "version_astilectron":"0.56.0",
-  "resources_path": "axolotl-web/dist"
-}


### PR DESCRIPTION
With v2 no longer using Electron, I propose to also remove this config file.