### PR TITLE
[axolotl-web] Remove babel config file

### DIFF
--- a/axolotl-web/babel.config.js
+++ b/axolotl-web/babel.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  presets: [
-    '@vue/cli-plugin-babel/preset'
-  ]
-}


### PR DESCRIPTION
As far as I understand the current state of the project, there is no babel used anymore.

As such, I propose to remove this config file.