### PR TITLE
Add dependabot post workflow to update Flatpak sources

### DIFF
--- a/.github/workflows/dependabot-post.yml
+++ b/.github/workflows/dependabot-post.yml
@@ -1,0 +1,56 @@
+name: Dependabot post-run
+
+on:
+  pull_request:
+    branches:
+      - dependabot/npm_and_yarn/**
+      - dependabot/cargo/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flatpak-sources-update:
+    name: Update Flatpak sources
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # Check out correct branch also for PRs from forks
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        # Fetch whole history as we want to commit and push
+        fetch-depth: 0
+    
+    - name: Clone flatpak-builder-tools
+      uses: actions/checkout@v4
+      with:
+        repository: flatpak/flatpak-builder-tools
+        path: flatpak-builder-tools
+      
+    - name: Install flatpak-builder-tools dependencies
+      run: |
+        sudo apt install -y pipx python3 python3-aiohttp python3-toml python3-yaml
+
+    - name: Update NodeJS sources
+      working-directory: flatpak-builder-tools/node
+      run: |
+        pipx install .
+        flatpak-node-generator yarn ${{ github.workspace }}/axolotl-web/yarn.lock -o ${{ github.workspace }}/flatpak/node-sources.json
+
+    - name: Update Cargo sources
+      working-directory: flatpak-builder-tools/cargo
+      run: python3 flatpak-cargo-generator.py ${{ github.workspace }}/Cargo.lock -o ${{ github.workspace }}/flatpak/cargo-sources.json
+  
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        # Ignore other changes like the cloned flatpak-builder-tools repo
+        file_pattern: 'flatpak/*-sources.json'
+        # Do not block dependabot from updating this PR: https://github.com/dependabot/dependabot-core/issues/1758
+        commit_message: '[dependabot skip] Update Flatpak sources'
+        commit_author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+        # Do not overwrite in case our version is outdated
+        push_options: '--force-with-lease'


### PR DESCRIPTION
Currently, the dependabot workflows will always fail the Flatpak build as the source manifests are not updated.

This will automatically add a commit to Dependabot PRs to update the Flatpak source manifests.