### PR TITLE
Fix dependabot workflow trigger

### DIFF
--- a/.github/workflows/dependabot-post.yml
+++ b/.github/workflows/dependabot-post.yml
@@ -1,7 +1,7 @@
 name: Dependabot post-run
 
 on:
-  pull_request:
+  push:
     branches:
       - dependabot/npm_and_yarn/**
       - dependabot/cargo/**


### PR DESCRIPTION
Noticed that `branches` filter for `pull_request` is the target branch instead of the head branch. Using `push` event instead.