### PR TITLE
axolotl-web: enable automatic formatting with prettier

### DIFF
--- a/axolotl-web/.eslintrc.cjs
+++ b/axolotl-web/.eslintrc.cjs
@@ -5,41 +5,38 @@ module.exports = {
     es2021: true,
   },
 
-  extends: [
-    "plugin:vue/vue3-recommended",
-    "plugin:prettier/recommended"
-  ],
+  extends: ['plugin:vue/vue3-recommended', 'plugin:prettier/recommended'],
 
   rules: {
-    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
-    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
-    "comma-dangle": "off",
-    "class-methods-use-this": "off",
-    "import/no-unresolved": "off",
-    "import/extensions": "off",
-    "implicit-arrow-linebreak": "off",
-    "import/prefer-default-export": "off",
-    "vue/no-mutating-props": "off",
-    "vue/singleline-html-element-content-newline": "off",
-    "vue/max-attributes-per-line": "off",
-    "vue/component-name-in-template-casing": "off",
-    "vue/html-self-closing": [
-      "error",
+    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'comma-dangle': 'off',
+    'class-methods-use-this': 'off',
+    'import/no-unresolved': 'off',
+    'import/extensions': 'off',
+    'implicit-arrow-linebreak': 'off',
+    'import/prefer-default-export': 'off',
+    'vue/no-mutating-props': 'off',
+    'vue/singleline-html-element-content-newline': 'off',
+    'vue/max-attributes-per-line': 'off',
+    'vue/component-name-in-template-casing': 'off',
+    'vue/html-self-closing': [
+      'error',
       {
         html: {
-          void: "any",
-          normal: "always",
-          component: "always",
+          void: 'any',
+          normal: 'always',
+          component: 'always',
         },
-        svg: "always",
-        math: "always",
+        svg: 'always',
+        math: 'always',
       },
     ],
   },
 
   overrides: [
     {
-      files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
+      files: ['**/__tests__/*.{j,t}s?(x)', '**/tests/unit/**/*.spec.{j,t}s?(x)'],
       env: {
         mocha: true,
       },

--- a/axolotl-web/.eslintrc.cjs
+++ b/axolotl-web/.eslintrc.cjs
@@ -5,7 +5,10 @@ module.exports = {
     es2021: true,
   },
 
-  extends: ["plugin:vue/vue3-recommended"],
+  extends: [
+    "plugin:vue/vue3-recommended",
+    "plugin:prettier/recommended"
+  ],
 
   rules: {
     "no-console": process.env.NODE_ENV === "production" ? "error" : "off",

--- a/axolotl-web/package.json
+++ b/axolotl-web/package.json
@@ -67,6 +67,10 @@
     "last 2 versions",
     "chrome 69"
   ],
+  "prettier":{
+    "singleQuote": true,
+    "htmlWhitespaceSensitivity": "ignore"
+  },
   "//": [
     "the support for chrome version 69 ensures support",
     "for the chromium version used by QtWebEngine 5.12."

--- a/axolotl-web/src/App.vue
+++ b/axolotl-web/src/App.vue
@@ -7,11 +7,11 @@
 
 <script>
 window.getCookie = function (cname) {
-  const name = cname + "=";
-  const ca = document.cookie.split(";");
+  const name = cname + '=';
+  const ca = document.cookie.split(';');
   for (let i = 0; i < ca.length; i++) {
     let c = ca[i];
-    while (c.charAt(0) === " ") {
+    while (c.charAt(0) === ' ') {
       c = c.substring(1);
     }
     if (c.indexOf(name) === 0) {
@@ -20,16 +20,16 @@ window.getCookie = function (cname) {
   }
   return false;
 };
-if (window.getCookie("darkMode") === "true") {
-  import("./assets/dark.scss");
+if (window.getCookie('darkMode') === 'true') {
+  import('./assets/dark.scss');
 } else {
-  import("./assets/light.scss");
+  import('./assets/light.scss');
 }
-import { router } from "./router/router";
-import ErrorModal from "@/components/ErrorModal.vue";
+import { router } from './router/router';
+import ErrorModal from '@/components/ErrorModal.vue';
 
 export default {
-  name: "AxolotlWeb",
+  name: 'AxolotlWeb',
   components: {
     ErrorModal,
   },
@@ -48,7 +48,7 @@ export default {
   watch: {
     nbTappedForDebug() {
       if (this.nbTappedForDebug >= 9) {
-        router.push("/debug");
+        router.push('/debug');
       }
     },
   },
@@ -76,7 +76,7 @@ export default {
 html,
 body,
 #app {
-  font-family: "ubuntu";
+  font-family: 'ubuntu';
   display: flex;
   flex-direction: column;
 }
@@ -84,7 +84,6 @@ body,
 body {
   max-height: 100vh;
   overflow: hidden;
-
 }
 
 main {

--- a/axolotl-web/src/components/AddContactModal.vue
+++ b/axolotl-web/src/components/AddContactModal.vue
@@ -13,17 +13,17 @@
           </button>
         </div>
         <div class="modal-body">
-          <span><strong v-translate>After adding a contact, it takes a few seconds for checking if the contact is registered with signal.</strong></span>
+          <span>
+            <strong v-translate>
+              After adding a contact, it takes a few seconds for checking if the contact is
+              registered with signal.
+            </strong>
+          </span>
         </div>
         <div class="modal-body">
           <div class="form-group">
             <label v-translate for="nameInput">Name</label>
-            <input
-              id="nameInput"
-              v-model="name"
-              type="text"
-              class="form-control"
-            >
+            <input id="nameInput" v-model="name" type="text" class="form-control" />
           </div>
           <div class="form-group">
             <label v-translate for="phoneInput">Phone</label>
@@ -33,7 +33,7 @@
               type="text"
               class="form-control"
               placeholder="+44..."
-            >
+            />
           </div>
         </div>
         <div class="modal-footer">
@@ -41,7 +41,7 @@
             v-translate
             type="button"
             class="btn btn-primary"
-            @click="$emit('add', { name: name, phone: phone, uuid:uuid })"
+            @click="$emit('add', { name: name, phone: phone, uuid: uuid })"
           >
             Add
           </button>
@@ -53,31 +53,31 @@
 
 <script>
 export default {
-  name: "AddContactModal",
+  name: 'AddContactModal',
   props: {
     number: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
     uuid: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
   },
-  emits: ["close", "add"],
+  emits: ['close', 'add'],
   data() {
     return {
-      phone: "",
-      name: "",
+      phone: '',
+      name: '',
     };
   },
   mounted() {
     if (this.number) {
       this.phone = this.number;
-      this.name = "";
-    } 
+      this.name = '';
+    }
   },
 };
 </script>

--- a/axolotl-web/src/components/AddDeviceModal.vue
+++ b/axolotl-web/src/components/AddDeviceModal.vue
@@ -16,21 +16,11 @@
           </ul>
           <div class="form-group">
             <label v-translate for="inputQRCode">QR code</label>
-            <input
-              id="inputQRCode"
-              v-model="qrCode"
-              type="text"
-              class="form-control"
-            >
+            <input id="inputQRCode" v-model="qrCode" type="text" class="form-control" />
           </div>
         </div>
         <div class="modal-footer">
-          <button
-            v-translate
-            type="button"
-            class="btn btn-primary"
-            @click="$emit('add', qrCode)"
-          >
+          <button v-translate type="button" class="btn btn-primary" @click="$emit('add', qrCode)">
             Add
           </button>
         </div>
@@ -41,11 +31,11 @@
 
 <script>
 export default {
-  name: "AddDeviceModal",
-  emits: ["close", "add"],
+  name: 'AddDeviceModal',
+  emits: ['close', 'add'],
   data() {
     return {
-      qrCode: "",
+      qrCode: '',
     };
   },
 };

--- a/axolotl-web/src/components/AddGroupMembersModal.vue
+++ b/axolotl-web/src/components/AddGroupMembersModal.vue
@@ -5,11 +5,7 @@
         <div class="modal-header">
           <h5 v-translate class="modal-title">Add members</h5>
           <div v-if="!searchActive" class="actions">
-            <button
-              type="button"
-              class="btn search"
-              @click="searchActive = true"
-            >
+            <button type="button" class="btn search" @click="searchActive = true">
               <font-awesome-icon icon="search" />
             </button>
             <button type="button" class="btn" @click="$emit('close')">
@@ -24,7 +20,7 @@
                 class="form-control"
                 @change="filterContacts()"
                 @keyup="filterContacts()"
-              >
+              />
             </div>
             <button type="button" class="btn" @click="searchActive = false">
               <font-awesome-icon icon="times" />
@@ -34,11 +30,7 @@
         <div class="modal-body">
           <div class="contact-list">
             <div v-if="contacts.length > 0 && contactsFilter === ''">
-              <div
-                v-for="contact in contacts"
-                :key="contact.UUID"
-                class="btn col-12 chat"
-              >
+              <div v-for="contact in contacts" :key="contact.UUID" class="btn col-12 chat">
                 <div class="row chat-entry">
                   <div class="avatar col-3" @click="contactClick(contact)">
                     <div v-if="contact.Name" class="badge-name">
@@ -82,53 +74,47 @@
 </template>
 
 <script>
-import { validateUUID } from "@/helpers/uuidCheck";
+import { validateUUID } from '@/helpers/uuidCheck';
 
 export default {
-  name: "AddGroupMembersModal",
+  name: 'AddGroupMembersModal',
   props: {
     alreadyAdded: {
       type: Array,
-      default: () => []
+      default: () => [],
     },
   },
-  emits: ["add", "close"],
+  emits: ['add', 'close'],
   data() {
     return {
       contacts: [],
       searchActive: false,
-      contactsFilter: "",
+      contactsFilter: '',
     };
   },
   computed: {
     contactsFiltered() {
-      return this.filterForOnlyContactsWithUUID(
-        this.$store.state.contactsFiltered
-      );
+      return this.filterForOnlyContactsWithUUID(this.$store.state.contactsFiltered);
     },
   },
   watch: {
     alreadyAdded() {
-      this.contacts = this.filterForOnlyContactsWithUUID(
-        this.$store.state.contacts
-      );
+      this.contacts = this.filterForOnlyContactsWithUUID(this.$store.state.contacts);
     },
   },
   mounted() {
-    this.contacts = this.filterForOnlyContactsWithUUID(
-      this.$store.state.contacts
-    );
+    this.contacts = this.filterForOnlyContactsWithUUID(this.$store.state.contacts);
   },
   methods: {
     validateUUID,
     contactClick(contact) {
-      this.$store.dispatch("addNewGroupMember", contact);
+      this.$store.dispatch('addNewGroupMember', contact);
     },
     filterContacts() {
-      if (this.contactsFilter !== "") {
-        this.$store.dispatch("filterContactsForGroup", this.contactsFilter);
+      if (this.contactsFilter !== '') {
+        this.$store.dispatch('filterContactsForGroup', this.contactsFilter);
       } else {
-        this.$store.dispatch("clearFilterContacts");
+        this.$store.dispatch('clearFilterContacts');
       }
     },
     filterForOnlyContactsWithUUID(contacts) {
@@ -141,7 +127,7 @@ export default {
         const found = this.alreadyAdded.find((element) => {
           return element.Tel === c.Tel;
         });
-        return typeof found === "undefined";
+        return typeof found === 'undefined';
       });
     },
   },

--- a/axolotl-web/src/components/AttachmentBar.vue
+++ b/axolotl-web/src/components/AttachmentBar.vue
@@ -9,15 +9,9 @@
           </button>
         </div>
         <div class="modal-body">
-          <button v-translate class="btn btn-primary" @click="$emit('send', 'photo')">
-            Photo
-          </button>
-          <button v-translate class="btn btn-primary" @click="$emit('send', 'video')">
-            Video
-          </button>
-          <button v-translate class="btn btn-primary" @click="$emit('send', 'audio')">
-            Audio
-          </button>
+          <button v-translate class="btn btn-primary" @click="$emit('send', 'photo')">Photo</button>
+          <button v-translate class="btn btn-primary" @click="$emit('send', 'video')">Video</button>
+          <button v-translate class="btn btn-primary" @click="$emit('send', 'audio')">Audio</button>
           <button v-translate class="btn btn-primary" @click="$emit('send', 'document')">
             Document
           </button>
@@ -29,11 +23,11 @@
 
 <script>
 export default {
-  name: "AttachmentBarComponent",
-  emits: ["send", "close"],
+  name: 'AttachmentBarComponent',
+  emits: ['send', 'close'],
   methods: {
     close() {
-      this.$emit("close");
+      this.$emit('close');
     },
   },
 };
@@ -55,7 +49,7 @@ export default {
   .modal-title {
     display: flex;
 
-    &>div {
+    & > div {
       margin-left: 10px;
     }
   }

--- a/axolotl-web/src/components/ConfirmationModal.vue
+++ b/axolotl-web/src/components/ConfirmationModal.vue
@@ -11,12 +11,7 @@
         <div class="modal-body">
           {{ text }}
           <div class="modal-footer">
-            <button
-              v-translate
-              type="button"
-              class="btn btn-primary"
-              @click="$emit('confirm')"
-            >
+            <button v-translate type="button" class="btn btn-primary" @click="$emit('confirm')">
               Confirm
             </button>
           </div>
@@ -28,18 +23,18 @@
 
 <script>
 export default {
-  name: "ConfirmationModal",
+  name: 'ConfirmationModal',
   props: {
     title: {
       type: String,
-      default: ""
+      default: '',
     },
     text: {
       type: String,
-      default: ""
+      default: '',
     },
   },
-  emits: ["close", "confirm"],
+  emits: ['close', 'confirm'],
 };
 </script>
 <style scoped>

--- a/axolotl-web/src/components/EditContactModal.vue
+++ b/axolotl-web/src/components/EditContactModal.vue
@@ -20,7 +20,7 @@
               type="text"
               class="form-control"
               placeholder="Enter name"
-            >
+            />
           </div>
           <div class="form-group">
             <label v-translate for="nameInput">Phone</label>
@@ -30,7 +30,7 @@
               type="text"
               class="form-control"
               placeholder="+44..."
-            >
+            />
           </div>
         </div>
         <div class="modal-footer">
@@ -50,22 +50,22 @@
 
 <script>
 export default {
-  name: "EditContactModal",
+  name: 'EditContactModal',
   props: {
     contact: {
       type: Object,
-      default: () => {}
+      default: () => {},
     },
     id: {
       type: String,
-      default: ""
+      default: '',
     },
   },
-  emits: ["close", "save"],
+  emits: ['close', 'save'],
   data() {
     return {
-      phone: "",
-      name: "",
+      phone: '',
+      name: '',
     };
   },
 };

--- a/axolotl-web/src/components/ErrorModal.vue
+++ b/axolotl-web/src/components/ErrorModal.vue
@@ -3,40 +3,31 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 v-translate class="modal-title">
-            Error communicating with Signal servers
-          </h5>
+          <h5 v-translate class="modal-title">Error communicating with Signal servers</h5>
           <button type="button" class="close btn" @click="close">
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
         <div class="modal-body">
           <p v-translate>
-            Axolotl encountered an error communicating with Signal servers.
-            Please try again.
+            Axolotl encountered an error communicating with Signal servers. Please try again.
           </p>
           <p v-translate>
             If you're seeing that error multiple times, check the
-            <a href="https://status.signal.org/" target="_blank">status of Signal servers</a>. If it's fine, then please tell us there is a problem by
-            <a href="https://github.com/nanu-c/axolotl/issues" target="_blank">opening an issue</a>.
+            <a href="https://status.signal.org/" target="_blank">status of Signal servers</a>
+            . If it's fine, then please tell us there is a problem by
+            <a href="https://github.com/nanu-c/axolotl/issues" target="_blank">opening an issue</a>
+            .
           </p>
           <p v-translate>
             If you think that something is wrong on your side, you can
-            <a @click="unregister">unregister</a> and register again.
-            Be careful,
-            <strong>your encryption key will change and you will lose all your
-              messages</strong>
+            <a @click="unregister">unregister</a>
+            and register again. Be careful,
+            <strong>your encryption key will change and you will lose all your messages</strong>
             if you choose to do that.
           </p>
           <div class="modal-footer">
-            <button
-              v-translate
-              type="button"
-              class="btn btn-primary"
-              @click="close"
-            >
-              Close
-            </button>
+            <button v-translate type="button" class="btn btn-primary" @click="close">Close</button>
           </div>
         </div>
       </div>
@@ -46,7 +37,7 @@
 
 <script>
 export default {
-  name: "ErrorModal",
+  name: 'ErrorModal',
   computed: {
     error() {
       return this.$store.state.error;
@@ -55,11 +46,9 @@ export default {
   methods: {
     unregister() {
       if (
-        confirm(
-          "You are about to lose all your messages, are you sure you want to unregister?"
-        )
+        confirm('You are about to lose all your messages, are you sure you want to unregister?')
       ) {
-        this.$store.dispatch("unregister");
+        this.$store.dispatch('unregister');
         location.reload();
       }
     },

--- a/axolotl-web/src/components/IdentityModal.vue
+++ b/axolotl-web/src/components/IdentityModal.vue
@@ -33,18 +33,18 @@
 </template>
 
 <script lang="ts">
-import QRCode from "qrcode";
-import { mapState } from "vuex";
+import QRCode from 'qrcode';
+import { mapState } from 'vuex';
 export default {
-  name: "IdentityModal",
-  emits: ["close", "confirm"],
+  name: 'IdentityModal',
+  emits: ['close', 'confirm'],
   data() {
     return {
       errorMessage: null,
     };
   },
   computed: {
-    ...mapState(["fingerprint", "sessionNames"]),
+    ...mapState(['fingerprint', 'sessionNames']),
     currentChat() {
       return this.$store.state.currentChat;
     },
@@ -52,14 +52,14 @@ export default {
   watch: {
     fingerprint() {
       QRCode.toCanvas(
-        document.getElementById("qrcode"),
+        document.getElementById('qrcode'),
         [
           {
             data: this.fingerprint.qrCode,
-            mode: "byte",
+            mode: 'byte',
           },
         ],
-        { errorCorrectionLevel: "L" }
+        { errorCorrectionLevel: 'L' },
       );
     },
   },
@@ -88,7 +88,7 @@ export default {
   display: flex;
 }
 
-.modal-title>div {
+.modal-title > div {
   margin-left: 10px;
 }
 

--- a/axolotl-web/src/components/ImportUnavailableModal.vue
+++ b/axolotl-web/src/components/ImportUnavailableModal.vue
@@ -3,36 +3,28 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 v-translate class="modal-title">
-            Import contacts feature unavailable
-          </h5>
+          <h5 v-translate class="modal-title">Import contacts feature unavailable</h5>
         </div>
         <div class="modal-body">
           <span v-translate>
-            We are sorry, but due to a change in the Signal protocol, automatic
-            import of contacts is currently unavailable.
+            We are sorry, but due to a change in the Signal protocol, automatic import of contacts
+            is currently unavailable.
           </span>
         </div>
         <div class="modal-body">
           <span v-translate>
-            If you are really sure that the persons you want to text with have
-            Signal, you can manually add them using the "plus" action on that
-            page.
+            If you are really sure that the persons you want to text with have Signal, you can
+            manually add them using the "plus" action on that page.
           </span>
         </div>
         <div class="modal-body">
           <span v-translate>
-            Be careful, if you add too many numbers which aren't Signal
-            accounts, you won't be able to add contacts anymore.
+            Be careful, if you add too many numbers which aren't Signal accounts, you won't be able
+            to add contacts anymore.
           </span>
         </div>
         <div class="modal-footer">
-          <button
-            v-translate
-            type="button"
-            class="btn btn-primary"
-            @click="$emit('close')"
-          >
+          <button v-translate type="button" class="btn btn-primary" @click="$emit('close')">
             Close
           </button>
         </div>
@@ -43,8 +35,8 @@
 
 <script>
 export default {
-  name: "ImportUnavailableModal",
-  emits: ["close"],
+  name: 'ImportUnavailableModal',
+  emits: ['close'],
 };
 </script>
 

--- a/axolotl-web/src/components/ImportVcfModal.vue
+++ b/axolotl-web/src/components/ImportVcfModal.vue
@@ -11,7 +11,12 @@
           </button>
         </div>
         <div class="modal-body">
-          <span><strong v-translate>Contacts can be added through a vcf contacts file. If an contact has multiple numbers, all of them will be added as separate contacts.</strong></span>
+          <span>
+            <strong v-translate>
+              Contacts can be added through a vcf contacts file. If an contact has multiple numbers,
+              all of them will be added as separate contacts.
+            </strong>
+          </span>
         </div>
         <div class="modal-body">
           <input
@@ -23,12 +28,7 @@
           />
         </div>
         <div class="modal-footer">
-          <button
-            v-translate
-            type="button"
-            class="btn btn-primary"
-            @click="refreshContacts()"
-          >
+          <button v-translate type="button" class="btn btn-primary" @click="refreshContacts()">
             Import vcf
           </button>
         </div>
@@ -38,36 +38,34 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
+import { mapState } from 'vuex';
 export default {
-  name: "ImportVcfModal",
+  name: 'ImportVcfModal',
   props: {
     number: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
     uuid: {
       type: String,
       required: false,
-      default: null
+      default: null,
     },
   },
-  emits: ["close", "add"],
+  emits: ['close', 'add'],
   data() {
     return {
-      phone: "",
-      name: "",
+      phone: '',
+      name: '',
     };
   },
-  computed: mapState([
-    "gui",
-  ]),
+  computed: mapState(['gui']),
   mounted() {
     if (this.number) {
       this.phone = this.number;
-      this.name = "";
-    } 
+      this.name = '';
+    }
   },
   methods: {
     readVcf(evt) {
@@ -77,26 +75,25 @@ export default {
         const that = this;
         r.onload = function (e) {
           const vcf = e.target.result;
-          that.$store.dispatch("uploadVcf", vcf);
+          that.$store.dispatch('uploadVcf', vcf);
         };
         r.readAsText(f);
-        this.$emit("close");
+        this.$emit('close');
       } else {
-        alert("Failed to load file");
+        alert('Failed to load file');
       }
     },
     refreshContacts() {
       this.$store.state.importingContacts = true;
       // console.log("Import contacts for gui " + this.gui)
       this.showSettingsMenu = false;
-      if (this.gui === "ut") {
-        const result = window.prompt("refreshContacts");
-        if (result !== "canceled")
-          this.$store.dispatch("refreshContacts", result);
-          this.$emit("close");
+      if (this.gui === 'ut') {
+        const result = window.prompt('refreshContacts');
+        if (result !== 'canceled') this.$store.dispatch('refreshContacts', result);
+        this.$emit('close');
       } else {
         this.showSettingsMenu = false;
-        document.getElementById("addVcf").click();
+        document.getElementById('addVcf').click();
       }
     },
   },

--- a/axolotl-web/src/components/LegacyHeader.vue
+++ b/axolotl-web/src/components/LegacyHeader.vue
@@ -10,10 +10,7 @@
             <button class="btn" @click="$router.push('/')">
               <font-awesome-icon icon="arrow-left" />
             </button>
-            <div
-              v-if="currentChat !== null && currentChat && currentChat.thread"
-              class="row w-100"
-            >
+            <div v-if="currentChat !== null && currentChat && currentChat.thread" class="row w-100">
               <div class="col-2 badge-container">
                 <div
                   v-if="!isGroup"
@@ -23,8 +20,7 @@
                   <img
                     class="avatar-img"
                     :src="
-                      'http://localhost:9080/attachments/avatars/' +
-                        currentChat?.thread?.Contact
+                      'http://localhost:9080/attachments/avatars/' + currentChat?.thread?.Contact
                     "
                     @error="onImageError($event)"
                   />
@@ -61,11 +57,7 @@
                   </div>
                   <div class="col-12">
                     <div
-                      v-if="
-                        isGroup &&
-                          currentGroup !== null &&
-                          typeof currentGroup !== 'undefined'
-                      "
+                      v-if="isGroup && currentGroup !== null && typeof currentGroup !== 'undefined'"
                       class="number-text"
                     >
                       <div v-for="e in currentGroup.Members" :key="e">
@@ -73,15 +65,12 @@
                       </div>
                     </div>
                     <div
-                      v-if="
-                        isGroup &&
-                          currentGroup !== null &&
-                          typeof currentGroup !== 'undefined'
-                      "
+                      v-if="isGroup && currentGroup !== null && typeof currentGroup !== 'undefined'"
                       class="number-text"
                     >
                       <div v-for="(n, i) in names" :key="i" class="name">
-                        {{ n }}<span v-if="i < names.length - 1">,</span>
+                        {{ n }}
+                        <span v-if="i < names.length - 1">,</span>
                       </div>
                     </div>
                     <div
@@ -115,11 +104,7 @@
                 aria-labelledby="dropdownMenuButton"
               >
                 <button
-                  v-if="
-                    currentChat !== null &&
-                      !isGroup &&
-                      currentChat.title !== currentChat.Tel
-                  "
+                  v-if="currentChat !== null && !isGroup && currentChat.title !== currentChat.Tel"
                   class="dropdown-item"
                   @click="callNumber(currentChat.Tel)"
                 >
@@ -133,20 +118,11 @@
                 >
                   Mute
                 </button>
-                <button
-                  v-else
-                  v-translate
-                  class="dropdown-item"
-                  @click="toggleNotifications"
-                >
+                <button v-else v-translate class="dropdown-item" @click="toggleNotifications">
                   Unmute
                 </button>
                 <button
-                  v-if="
-                    currentChat !== null &&
-                      !isGroup &&
-                      currentChat.title === currentChat.Tel
-                  "
+                  v-if="currentChat !== null && !isGroup && currentChat.title === currentChat.Tel"
                   v-translate
                   class="dropdown-item"
                   @click="addContactModal = true"
@@ -154,11 +130,7 @@
                   Add contact
                 </button>
                 <button
-                  v-if="
-                    currentChat !== null &&
-                      !isGroup &&
-                      currentChat.title !== currentChat.Tel
-                  "
+                  v-if="currentChat !== null && !isGroup && currentChat.title !== currentChat.Tel"
                   v-translate
                   class="dropdown-item"
                   @click="openEditContactModal()"
@@ -369,13 +341,13 @@
 </template>
 
 <script>
-import IdentityModal from '@/components/IdentityModal.vue'
-import ConfirmationModal from '@/components/ConfirmationModal.vue'
-import ImportVcfModal from '@/components/ImportVcfModal.vue'
-import AddContactModal from '@/components/AddContactModal.vue'
-import EditContactModal from '@/components/EditContactModal.vue'
+import IdentityModal from '@/components/IdentityModal.vue';
+import ConfirmationModal from '@/components/ConfirmationModal.vue';
+import ImportVcfModal from '@/components/ImportVcfModal.vue';
+import AddContactModal from '@/components/AddContactModal.vue';
+import EditContactModal from '@/components/EditContactModal.vue';
 
-import { mapState } from 'vuex'
+import { mapState } from 'vuex';
 export default {
   name: 'HeaderComponent',
   components: {
@@ -400,7 +372,7 @@ export default {
       addContactModal: false,
       editContactModal: false,
       editContactId: -1,
-    }
+    };
   },
   computed: {
     ...mapState([
@@ -415,103 +387,100 @@ export default {
       'identity',
     ]),
     isGroup() {
-      return this.currentChat?.thread.Group !== undefined
+      return this.currentChat?.thread.Group !== undefined;
     },
   },
   watch: {
     $route() {
-      this.names = []
-      this.showSettingsMenu = false
+      this.names = [];
+      this.showSettingsMenu = false;
     },
     currentChat: {
       handler() {
-        this.names = []
-        this.showSettingsMenu = false
+        this.names = [];
+        this.showSettingsMenu = false;
       },
       deep: true,
     },
   },
   mounted() {
-    this.names = []
+    this.names = [];
   },
   methods: {
     route() {
-      return this.$route.name
+      return this.$route.name;
     },
     back() {
-      this.$router.go(-1)
-      this.showSettingsMenu = false
-      this.contactsFilter = ''
-      this.toggleSearch = false
-      this.names = []
+      this.$router.go(-1);
+      this.showSettingsMenu = false;
+      this.contactsFilter = '';
+      this.toggleSearch = false;
+      this.names = [];
     },
     toggleSettings() {
-      this.showSettingsMenu = !this.showSettingsMenu
+      this.showSettingsMenu = !this.showSettingsMenu;
     },
     toggleNotifications() {
-      this.showSettingsMenu = false
-      this.$store.dispatch('toggleNotifications')
+      this.showSettingsMenu = false;
+      this.$store.dispatch('toggleNotifications');
     },
     resetEncryptionModal() {
-      this.showSettingsMenu = false
-      this.showConfirmationModal = true
-      this.cMType = 'resetEncryption'
-      this.cMTitle = this.$gettext('Reset secure session?')
+      this.showSettingsMenu = false;
+      this.showConfirmationModal = true;
+      this.cMType = 'resetEncryption';
+      this.cMTitle = this.$gettext('Reset secure session?');
       this.cMText = this.$gettext(
-        "This may help if you're having encryption problems in this conversation. Your messages will be kept."
-      )
+        "This may help if you're having encryption problems in this conversation. Your messages will be kept.",
+      );
     },
     verifyIdentity() {
-      this.$store.dispatch('verifyIdentity')
-      this.showSettingsMenu = false
-      this.showIdentityModal = true
+      this.$store.dispatch('verifyIdentity');
+      this.showSettingsMenu = false;
+      this.showIdentityModal = true;
     },
     delChatModal() {
-      this.showSettingsMenu = false
-      this.showConfirmationModal = true
-      this.cMType = 'delChat'
-      this.cMTitle = this.$gettext('Delete this chat?')
+      this.showSettingsMenu = false;
+      this.showConfirmationModal = true;
+      this.cMType = 'delChat';
+      this.cMTitle = this.$gettext('Delete this chat?');
       this.cMText = this.$gettext(
-        'This chat will be permanently deleted - but only from your device.'
-      )
+        'This chat will be permanently deleted - but only from your device.',
+      );
     },
     confirm() {
-      if (this.cMType === 'resetEncryption') this.$store.dispatch('resetEncryption')
-      else if (this.cMType === 'delChat')
-        this.$store.dispatch('delChat', this.currentChat.thread)
-      this.$router.push('/chatList')
-      this.showConfirmationModal = false
-      this.showIdentityModal = false
+      if (this.cMType === 'resetEncryption') this.$store.dispatch('resetEncryption');
+      else if (this.cMType === 'delChat') this.$store.dispatch('delChat', this.currentChat.thread);
+      this.$router.push('/chatList');
+      this.showConfirmationModal = false;
+      this.showIdentityModal = false;
     },
     showSearch() {
       if (this.toggleSearch) {
-        this.toggleSearch = false
-        this.$store.dispatch('clearFilterContacts')
-      } else this.toggleSearch = true
+        this.toggleSearch = false;
+        this.$store.dispatch('clearFilterContacts');
+      } else this.toggleSearch = true;
     },
     onImageError(event) {
-      event.target.style.display = 'none'
+      event.target.style.display = 'none';
     },
     filterContacts() {
-      if (this.contactsFilter !== '')
-        this.$store.dispatch('filterContacts', this.contactsFilter)
-      else this.$store.dispatch('clearFilterContacts')
+      if (this.contactsFilter !== '') this.$store.dispatch('filterContacts', this.contactsFilter);
+      else this.$store.dispatch('clearFilterContacts');
     },
     getNameForTel(tel) {
       this.contacts.forEach((c) => {
         if (c.Tel === tel) {
-          if (this.names.length <= 3 && this.names.indexOf(c.Name) === -1)
-            this.names.push(c.Name)
-          return c
-        } else return tel
-      })
+          if (this.names.length <= 3 && this.names.indexOf(c.Name) === -1) this.names.push(c.Name);
+          return c;
+        } else return tel;
+      });
     },
     callNumber(n) {
       if (this.gui === 'ut') {
-        window.prompt('call' + n)
-        this.showSettingsMenu = false
+        window.prompt('call' + n);
+        this.showSettingsMenu = false;
       } else {
-        this.showSettingsMenu = false
+        this.showSettingsMenu = false;
       }
     },
     createGroup() {},
@@ -519,30 +488,30 @@ export default {
       const id = this.contacts.findIndex(
         (c) =>
           c.Tel === this.currentChat.Tel ||
-          c.UUID === this.sessionNames[this.currentChat.thread].Name
-      )
-      this.editContactId = id
+          c.UUID === this.sessionNames[this.currentChat.thread].Name,
+      );
+      this.editContactId = id;
       if (id !== -1) {
-        this.editContactModal = true
+        this.editContactModal = true;
       }
     },
     addContact(data) {
-      this.$store.dispatch('addContact', data)
-      this.addContactModal = false
+      this.$store.dispatch('addContact', data);
+      this.addContactModal = false;
     },
     saveContact(data) {
-      this.editContactModal = false
-      this.showActions = false
-      this.editContactId = ''
-      this.$store.dispatch('editContact', data)
+      this.editContactModal = false;
+      this.showActions = false;
+      this.editContactId = '';
+      this.$store.dispatch('editContact', data);
     },
     openProfileForRecipient(recipient) {
       if (recipient !== -1) {
-        this.$router.push(`/profile/${recipient}`)
+        this.$router.push(`/profile/${recipient}`);
       }
     },
   },
-}
+};
 </script>
 
 <style scoped>

--- a/axolotl-web/src/components/Message.vue
+++ b/axolotl-web/src/components/Message.vue
@@ -6,7 +6,7 @@
           (message.message_type === 'SyncMessage' &&
             message.message &&
             message.message !== 'SyncMessage'))) ||
-        message.attachments.length > 0
+      message.attachments.length > 0
     "
     :key="message.ID"
     :class="{
@@ -23,9 +23,7 @@
           message.Flags !== 13 &&
           message.Flags !== 14) ||
         message.StatusMessage ||
-        (message.Attachment &&
-          message.Attachment.includes('null') &&
-          message.Message === ''),
+        (message.Attachment && message.Attachment.includes('null') && message.Message === ''),
       hidden: message.Flags === 18,
       error: message.timestamp === 0 || message.SendingError,
       'group-message': isGroup,
@@ -78,34 +76,24 @@
             <div v-else-if="m.ctype === 'audio'" class="attachment-audio">
               <div class="audio-player-container d-flex">
                 <button id="play-icon">
-                  <font-awesome-icon
-                    v-if="!isPlaying"
-                    class="play"
-                    icon="play"
-                    @click="play"
-                  />
-                  <font-awesome-icon
-                    v-if="isPlaying"
-                    class="pause"
-                    icon="pause"
-                    @click="pause"
-                  />
+                  <font-awesome-icon v-if="!isPlaying" class="play" icon="play" @click="play" />
+                  <font-awesome-icon v-if="isPlaying" class="pause" icon="pause" @click="pause" />
                 </button>
-                <span v-if="!isPlaying" id="duration" class="time">{{
-                  humanifyTimePeriod(duration)
-                }}</span>
-                <span v-if="isPlaying" id="currentTime" class="time">{{ humanifyTimePeriod(currentTime) }} /
-                  {{ humanifyTimePeriod(duration) }}</span>
+                <span v-if="!isPlaying" id="duration" class="time">
+                  {{ humanifyTimePeriod(duration) }}
+                </span>
+                <span v-if="isPlaying" id="currentTime" class="time">
+                  {{ humanifyTimePeriod(currentTime) }} / {{ humanifyTimePeriod(duration) }}
+                </span>
               </div>
             </div>
-            <div
-              v-else-if="m.filename !== '' && m.ctype === 'file'"
-              class="attachment-file"
-            >
+            <div v-else-if="m.filename !== '' && m.ctype === 'file'" class="attachment-file">
               <a
                 :href="'http://localhost:9080/attachments/' + m.filename"
                 @click="shareAttachment(m.filename, $event)"
-              >{{ m.fileName }}</a>
+              >
+                {{ m.fileName }}
+              </a>
             </div>
             <div
               v-else-if="m.ctype === 'video'"
@@ -143,21 +131,15 @@
           v-if="message.attachments.length === 0 && !message.message && !isGroup"
           class="status-message"
         >
-          <span v-translate>Set timer for self-destructing messages </span>
+          <span v-translate>Set timer for self-destructing messages</span>
           <div>{{ humanifyTimePeriod(message.ExpireTimer) }}</div>
         </div>
-        <div v-if="message.Flags === 10" v-translate>
-          Unsupported message type: sticker
-        </div>
+        <div v-if="message.Flags === 10" v-translate>Unsupported message type: sticker</div>
       </div>
       <div v-if="message.timestamp !== 0" class="meta">
         <div class="time">
-          <span @click="showDate = !showDate">{{
-            humanifyDateFromNow(message.timestamp)
-          }}</span>
-          <span v-if="showDate" class="fullDate">{{
-            humanifyDate(message.timestamp)
-          }}</span>
+          <span @click="showDate = !showDate">{{ humanifyDateFromNow(message.timestamp) }}</span>
+          <span v-if="showDate" class="fullDate">{{ humanifyDate(message.timestamp) }}</span>
         </div>
         <div v-if="message.ExpireTimer > 0">
           <div class="circle-wrap">
@@ -189,10 +171,10 @@
 </template>
 
 <script>
-import moment from 'moment'
-import { mapState } from 'vuex'
-import { router } from '@/router/router'
-let decoder
+import moment from 'moment';
+import { mapState } from 'vuex';
+import { router } from '@/router/router';
+let decoder;
 
 export default {
   name: 'MessageComponent',
@@ -216,33 +198,32 @@ export default {
       isPlaying: false,
       id: -1,
       senderName: '',
-    }
+    };
   },
   computed: {
     ...mapState(['currentGroup', 'config', 'contacts']),
     is_outgoing() {
-      if (this.message?.sender === this.config.uuid || this.message?.sender === null)
-        return true
+      if (this.message?.sender === this.config.uuid || this.message?.sender === null) return true;
       else if (this.message?.is_outgoing) {
-        return true
+        return true;
       } else {
-        return false
+        return false;
       }
     },
     isSenderNameDisplayed() {
-      return !this.is_outgoing && this.isGroup
+      return !this.is_outgoing && this.isGroup;
     },
     name() {
       if (this.senderName === '') {
-        const uuid = this.message.sender
+        const uuid = this.message.sender;
         const contact = this.contacts.find((element) => {
-          return element.uuid === uuid
-        })
+          return element.uuid === uuid;
+        });
         if (typeof contact !== 'undefined') {
-          return contact.name
+          return contact.name;
         }
       }
-      return this.senderName
+      return this.senderName;
     },
   },
   mounted() {
@@ -251,141 +232,141 @@ export default {
       this.message.Attachment !== '' &&
       this.message.Attachment !== null
     ) {
-      const attachment = JSON.parse(this.message.Attachment)
+      const attachment = JSON.parse(this.message.Attachment);
       if (attachment && attachment.length > 0 && attachment[0].CType === 3) {
-        this.audio = new Audio(`http://localhost:9080/attachments/${attachment[0].File}`)
-        var that = this
+        this.audio = new Audio(`http://localhost:9080/attachments/${attachment[0].File}`);
+        var that = this;
         this.audio.onloadedmetadata = function () {
-          that.duration = that.audio.duration.toFixed(2)
-        }
+          that.duration = that.audio.duration.toFixed(2);
+        };
         this.audio.onended = function () {
-          that.audio.currentTime = 0
-          that.isPlaying = false
-        }
+          that.audio.currentTime = 0;
+          that.isPlaying = false;
+        };
         this.audio.ontimeupdate = function () {
-          that.currentTime = that.audio.currentTime.toFixed(2)
-        }
+          that.currentTime = that.audio.currentTime.toFixed(2);
+        };
       }
     }
   },
   methods: {
     sanitize(msg) {
-      decoder = decoder || document.createElement('div')
-      decoder.textContent = msg
-      let result = decoder.innerHTML
-      decoder.textContent = result //escapes twice in order to negate v-html's unescaping
-      result = decoder.innerHTML
-      return result
+      decoder = decoder || document.createElement('div');
+      decoder.textContent = msg;
+      let result = decoder.innerHTML;
+      decoder.textContent = result; //escapes twice in order to negate v-html's unescaping
+      result = decoder.innerHTML;
+      return result;
     },
     onImageError(event) {
-      event.target.style.display = 'none'
+      event.target.style.display = 'none';
     },
     openProfileForRecipient(recipient) {
       if (recipient !== -1) {
-        router.push(`/profile/${recipient}`)
+        router.push(`/profile/${recipient}`);
       } else {
         this.$store.dispatch('createRecipientAndAddToGroup', {
           id: this.message.SourceUUID,
           group: this.currentGroup.HexId,
-        })
+        });
       }
     },
     getName() {
-      if (!this.isGroup) return ''
+      if (!this.isGroup) return '';
       if (this.contacts !== null) {
-        const uuid = this.message.sender
+        const uuid = this.message.sender;
         const contact = this.contacts.find((element) => {
-          return element.uuid === uuid
-        })
+          return element.uuid === uuid;
+        });
         if (typeof contact !== 'undefined') {
-          this.name = contact.name
-          return this.name
+          this.name = contact.name;
+          return this.name;
         }
       }
       if (this.currentGroup !== null && this.currentGroup.Members !== null) {
         const contact = this.currentGroup.Members.find(function (element) {
-          return element.UUID === uuid
-        })
+          return element.UUID === uuid;
+        });
         if (typeof contact !== 'undefined') {
-          this.id = contact.Id
-          if (contact.ProfileGivenName !== '') this.name = contact.ProfileGivenName
-          else this.name = contact.Username
-          return this.name
+          this.id = contact.Id;
+          if (contact.ProfileGivenName !== '') this.name = contact.ProfileGivenName;
+          else this.name = contact.Username;
+          return this.name;
         }
       }
-      this.name = this.message.sender
-      return this.message.sender
+      this.name = this.message.sender;
+      return this.message.sender;
     },
     isAttachmentArray(input) {
       try {
-        return JSON.parse(input)
+        return JSON.parse(input);
       } catch (e) {
-        return false
+        return false;
       }
       // JSON.parse(input)
     },
     shareAttachment(file, e) {
       if (typeof this.config.Gui !== 'undefined' && this.config.Gui === 'ut') {
-        e.preventDefault()
-        alert('[oD]' + file)
+        e.preventDefault();
+        alert('[oD]' + file);
         // this.showAttachmentsBar=true
       }
     },
     timerPercentage(m) {
-      const received = moment(m.ReceivedAt)
-      const duration = moment.duration(received.diff(moment.now()))
-      const percentage = 1 - (m.ExpireTimer + duration.asSeconds()) / m.ExpireTimer
+      const received = moment(m.ReceivedAt);
+      const duration = moment.duration(received.diff(moment.now()));
+      const percentage = 1 - (m.ExpireTimer + duration.asSeconds()) / m.ExpireTimer;
       if (percentage < 1) {
-        const fullCircle = 179
-        return fullCircle * percentage
-      } else return 0
+        const fullCircle = 179;
+        return fullCircle * percentage;
+      } else return 0;
     },
     verifySelfDestruction(m) {
       if (m.ExpireTimer !== 0) {
         if (m.ReceivedAt !== 0) {
           // hide destructed messages but not timer settings
-          const received = moment(m.ReceivedAt)
-          const duration = moment.duration(received.diff(moment.now()))
+          const received = moment(m.ReceivedAt);
+          const duration = moment.duration(received.diff(moment.now()));
           if (duration.asSeconds() + m.ExpireTimer < 0) {
-            this.$store.dispatch('deleteSelfDestructingMessage', m)
-            return false
+            this.$store.dispatch('deleteSelfDestructingMessage', m);
+            return false;
           }
         } else if (m.SentAt !== 0) {
-          const rS = moment(m.SentAt)
-          const durationS = moment.duration(rS.diff(moment.now()))
+          const rS = moment(m.SentAt);
+          const durationS = moment.duration(rS.diff(moment.now()));
           if (durationS.asSeconds() + m.ExpireTimer < 0 && m.Message !== '') {
-            this.$store.dispatch('deleteSelfDestructingMessage', m)
-            return false
+            this.$store.dispatch('deleteSelfDestructingMessage', m);
+            return false;
           }
         }
       }
-      return true
+      return true;
     },
     humanifyDate(inputDate) {
-      return new moment(inputDate).format('lll')
+      return new moment(inputDate).format('lll');
     },
     humanifyDateFromNow(inputDate) {
-      return new moment(inputDate).fromNow()
+      return new moment(inputDate).fromNow();
     },
     humanifyTimePeriod(time) {
-      if (time < 60) return time + ' s'
-      else if (time < 60 * 60) return time / 60 + ' m'
-      else if (time < 60 * 60 * 24) return time / 60 / 60 + ' h'
-      else if (time > 60 * 60 * 24) return time / 60 / 60 / 24 + ' d'
-      return time
+      if (time < 60) return time + ' s';
+      else if (time < 60 * 60) return time / 60 + ' m';
+      else if (time < 60 * 60 * 24) return time / 60 / 60 + ' h';
+      else if (time > 60 * 60 * 24) return time / 60 / 60 / 24 + ' d';
+      return time;
     },
     play() {
-      this.audio.play()
-      this.isPlaying = true
+      this.audio.play();
+      this.isPlaying = true;
     },
     pause() {
       if (this.audio && this.audio.currentTime > 0) {
-        this.audio.pause()
-        this.isPlaying = false
+        this.audio.pause();
+        this.isPlaying = false;
       }
     },
   },
-}
+};
 </script>
 
 <style lang="scss" scoped>

--- a/axolotl-web/src/components/VerificationPinInput.vue
+++ b/axolotl-web/src/components/VerificationPinInput.vue
@@ -17,39 +17,39 @@
         @paste="onPaste"
         @focus="newColor(index)"
         @blur="defaultColor(index)"
-      >
+      />
     </div>
   </div>
 </template>
 <script>
 export default {
-  name: "VerificationPinInputComponent",
+  name: 'VerificationPinInputComponent',
   props: {
     numberOfBoxes: {
       type: Number,
-      default: 6
+      default: 6,
     },
     position: {
       type: String,
-      default: "center"
+      default: 'center',
     },
     color: {
       type: String,
-      default: ""
+      default: '',
     },
     clearInput: {
       type: Boolean,
       default: false,
     },
   },
-  emits:['input-value','enter','clearValue'],
+  emits: ['input-value', 'enter', 'clearValue'],
 
   data() {
     return {
       arraySize: null,
       boxLength: null,
       direction: null,
-      boxColor: "#2090ea",
+      boxColor: '#2090ea',
       clearFlag: false,
     };
   },
@@ -57,88 +57,88 @@ export default {
   mounted() {
     this.handleBoxes();
 
-    if (typeof this.color !== "undefined" && this.color) {
+    if (typeof this.color !== 'undefined' && this.color) {
       this.boxColor = this.color;
     }
     this.clearFlag = this.clearInput;
     if (this.clearFlag) {
-      this.$emit("clearValue", "");
+      this.$emit('clearValue', '');
     }
     this.handleAlignment();
   },
   methods: {
     handleBoxes() {
-      if (typeof this.numberOfBoxes === "undefined" && !this.numberOfBoxes) {
+      if (typeof this.numberOfBoxes === 'undefined' && !this.numberOfBoxes) {
         this.boxLength = 6;
-        this.arraySize = Array(this.boxLength).fill("");
-      } else if (typeof this.numberOfBoxes === "number") {
+        this.arraySize = Array(this.boxLength).fill('');
+      } else if (typeof this.numberOfBoxes === 'number') {
         this.boxLength = this.numberOfBoxes;
-        this.arraySize = Array(this.boxLength).fill("");
+        this.arraySize = Array(this.boxLength).fill('');
       } else {
         this.boxLength = 6;
-        this.arraySize = Array(this.boxLength).fill("");
+        this.arraySize = Array(this.boxLength).fill('');
       }
     },
     handleAlignment() {
       switch (this.position) {
-        case "left":
-          this.direction = "flex-start";
+        case 'left':
+          this.direction = 'flex-start';
           break;
-        case "right":
-          this.direction = "flex-end";
+        case 'right':
+          this.direction = 'flex-end';
           break;
-        case "center":
-          this.direction = "center";
+        case 'center':
+          this.direction = 'center';
           break;
         default:
-          this.direction = "center";
+          this.direction = 'center';
       }
     },
     newColor(index) {
-      const i = "otp" + index;
+      const i = 'otp' + index;
       this.$refs[i][0].style.boxShadow = ` 0 0 5px  ${this.boxColor} inset`;
       this.$refs[i][0].style.border = `1px solid ${this.boxColor}`;
     },
     defaultColor(index) {
-      const i = "otp" + index;
-      this.$refs[i][0].style.boxShadow = " 0 0 5px #ccc inset";
-      this.$refs[i][0].style.border = "solid 1px #ccc";
+      const i = 'otp' + index;
+      this.$refs[i][0].style.boxShadow = ' 0 0 5px #ccc inset';
+      this.$refs[i][0].style.border = 'solid 1px #ccc';
     },
     focusElement(index) {
-      const i = "otp" + index;
+      const i = 'otp' + index;
       this.$refs[i][0].focus();
     },
     handleEnterKey(event) {
-      if (event.key === "Enter") {
-        this.$emit("enter");
+      if (event.key === 'Enter') {
+        this.$emit('enter');
         event.stopPropagation();
       }
     },
     sanitizeKeyData(key) {
-      return key === "Unidentified" ? undefined : key;
+      return key === 'Unidentified' ? undefined : key;
     },
     emitInput() {
-      const result = this.arraySize.join("").slice(0, this.numberOfBoxes);
-      this.$emit("input-value", result);
+      const result = this.arraySize.join('').slice(0, this.numberOfBoxes);
+      this.$emit('input-value', result);
     },
     handleKeyDown(event, index) {
       const key = this.sanitizeKeyData(event.key);
       if (!key) {
         return;
       }
-      if (key === "Backspace") {
+      if (key === 'Backspace') {
         if (this.arraySize[index]) {
-          return (this.arraySize[index] = "");
+          return (this.arraySize[index] = '');
         }
 
         if (index > 0) {
           this.focusElement(index - 1);
         }
-      } else if (!event.shiftKey && (key === "ArrowRight" || key === "Right")) {
+      } else if (!event.shiftKey && (key === 'ArrowRight' || key === 'Right')) {
         if (index < this.arraySize.length - 1) {
           this.focusElement(index + 1);
         }
-      } else if (!event.shiftKey && (key === "ArrowLeft" || key === "Left")) {
+      } else if (!event.shiftKey && (key === 'ArrowLeft' || key === 'Left')) {
         if (index > 0) {
           this.focusElement(index - 1);
         }
@@ -171,23 +171,21 @@ export default {
         return;
       }
       event.preventDefault();
-      const code =
-        clipboardData.getData("Text") || clipboardData.getData("text/plain");
+      const code = clipboardData.getData('Text') || clipboardData.getData('text/plain');
       this.fillCode(code);
       this.emitInput();
     },
     fillCode(code) {
       code = code.trim();
       code = code.slice(0, this.boxLength);
-      const parts = code.split("");
+      const parts = code.split('');
       parts.length = this.boxLength;
       this.arraySize = parts;
       const last = code.length - 1;
       setTimeout(() => {
-        this.arraySize[last] =
-          this.arraySize[last] && this.arraySize[last].slice(0, 1);
+        this.arraySize[last] = this.arraySize[last] && this.arraySize[last].slice(0, 1);
         this.$forceUpdate();
-        this.$refs["otp" + (this.arraySize.length - 1)][0].focus();
+        this.$refs['otp' + (this.arraySize.length - 1)][0].focus();
       }, 0);
     },
   },
@@ -230,7 +228,7 @@ input::-webkit-inner-spin-button {
   margin: 0;
 }
 
-input[type="tel"] {
+input[type='tel'] {
   -moz-appearance: textfield;
 }
 </style>

--- a/axolotl-web/src/config.js
+++ b/axolotl-web/src/config.js
@@ -1,7 +1,6 @@
-
 export const config = {
-    primaryRegistration: false,
-    secondaryRegistration: true,
-    contacts: false,
+  primaryRegistration: false,
+  secondaryRegistration: true,
+  contacts: false,
 };
 export default config;

--- a/axolotl-web/src/helpers/uuidCheck.js
+++ b/axolotl-web/src/helpers/uuidCheck.js
@@ -1,6 +1,6 @@
 const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const isValidV4UUID = uuid => uuidV4Regex.test(uuid);
+const isValidV4UUID = (uuid) => uuidV4Regex.test(uuid);
 export const validateUUID = function (uuid) {
-  var result = isValidV4UUID(uuid)
-  return result
-}
+  var result = isValidV4UUID(uuid);
+  return result;
+};

--- a/axolotl-web/src/layouts/Default.vue
+++ b/axolotl-web/src/layouts/Default.vue
@@ -4,11 +4,7 @@
       <div class="container">
         <div class="header-row row">
           <div class="col-2 header-left">
-            <button
-              v-if="$route.meta.hasBackButton"
-              class="btn"
-              @click="back()"
-            >
+            <button v-if="$route.meta.hasBackButton" class="btn" @click="back()">
               <font-awesome-icon icon="arrow-left" />
             </button>
           </div>
@@ -47,7 +43,7 @@
 </template>
 <script>
 export default {
-  name: "DefaultLayout",
+  name: 'DefaultLayout',
   data: () => ({
     showMenu: false,
   }),
@@ -83,7 +79,7 @@ export default {
 main {
   padding-top: 50px;
 }
-.header-left .btn{
+.header-left .btn {
   color: #fff;
 }
 </style>

--- a/axolotl-web/src/layouts/Legacy.vue
+++ b/axolotl-web/src/layouts/Legacy.vue
@@ -12,9 +12,9 @@
   </div>
 </template>
 <script>
-import LegacyHeader from "@/components/LegacyHeader.vue";
+import LegacyHeader from '@/components/LegacyHeader.vue';
 export default {
-  name: "LegacyLayout",
+  name: 'LegacyLayout',
   components: {
     LegacyHeader,
   },

--- a/axolotl-web/src/main.js
+++ b/axolotl-web/src/main.js
@@ -1,13 +1,13 @@
-import { createApp } from 'vue'
-import App from './App.vue'
-import VueNativeSock from 'vue-native-websocket-vue3'
-import store from './store/store'
-import { router } from "./router/router";
-import { createGettext } from "vue3-gettext";
-import translations from '../translations/translations.json'
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import linkifyHTML from 'linkify-html'
+import { createApp } from 'vue';
+import App from './App.vue';
+import VueNativeSock from 'vue-native-websocket-vue3';
+import store from './store/store';
+import { router } from './router/router';
+import { createGettext } from 'vue3-gettext';
+import translations from '../translations/translations.json';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import linkifyHTML from 'linkify-html';
 import 'bootstrap';
 
 import {
@@ -29,51 +29,61 @@ import {
   faUserFriends,
   faVolumeMute,
   faWrench,
-} from '@fortawesome/free-solid-svg-icons'
+} from '@fortawesome/free-solid-svg-icons';
 
-library.add(faArrowLeft, faEllipsisV, faPencilAlt, faPlus, faTrash, faPaperPlane,
-  faUserFriends, faTimes, faCheck, faVolumeMute, faHeart, faSearch, faArrowDown,
-  faMicrophone, faStopCircle, faPlay, faPause, faWrench
-  )
-const app = createApp(App)
-app.component('FontAwesomeIcon', FontAwesomeIcon)
+library.add(
+  faArrowLeft,
+  faEllipsisV,
+  faPencilAlt,
+  faPlus,
+  faTrash,
+  faPaperPlane,
+  faUserFriends,
+  faTimes,
+  faCheck,
+  faVolumeMute,
+  faHeart,
+  faSearch,
+  faArrowDown,
+  faMicrophone,
+  faStopCircle,
+  faPlay,
+  faPause,
+  faWrench,
+);
+const app = createApp(App);
+app.component('FontAwesomeIcon', FontAwesomeIcon);
 app.mixin({
   methods: {
     linkify(content) {
-      return linkifyHTML(
-        content,
-        {
-          defaultProtocol: 'https',
-          rel: {
-            url: 'noopener noreferrer'
-          },
-          target: {
-            url: '_blank'
-          },
-          className: 'linkified',
-          ignoreTags: [
-            'script',
-            'style'
-          ]
-        }
-      );
+      return linkifyHTML(content, {
+        defaultProtocol: 'https',
+        rel: {
+          url: 'noopener noreferrer',
+        },
+        target: {
+          url: '_blank',
+        },
+        className: 'linkified',
+        ignoreTags: ['script', 'style'],
+      });
     },
   },
-})
+});
 const gettext = createGettext({
-  defaultLanguage: "en",
+  defaultLanguage: 'en',
   translations,
 });
 app.use(gettext);
-app.config.productionTip = false
+app.config.productionTip = false;
 
 // set backend adress
-var websocketAdress = "ws://";
-if (window.location.protocol === "https:") {
-  websocketAdress = "wss://";
+var websocketAdress = 'ws://';
+if (window.location.protocol === 'https:') {
+  websocketAdress = 'wss://';
 }
 websocketAdress += window.location.host;
-websocketAdress += "/ws";
+websocketAdress += '/ws';
 
 // if (process.env.NODE_ENV === "development") {
 //   console.log(process.env)
@@ -86,17 +96,15 @@ websocketAdress += "/ws";
 websocketAdress = 'ws://localhost:9080/ws';
 
 // initialise connection to the backend
-app.use(VueNativeSock, websocketAdress,
-  {
-    store: store,
-    // format: 'json',
-    reconnection: true, // (Boolean) whether to reconnect automatically (false)
-    // reconnectionAttempts: 5, // (Number) number of reconnection attempts before giving up (Infinity),
-    reconnectionDelay: 3000, // (Number) how long to initially wait before attempting a new (1000) }
-  }
-)
-app.use(store)
-app.use(router)
-app.mount('#app')
+app.use(VueNativeSock, websocketAdress, {
+  store: store,
+  // format: 'json',
+  reconnection: true, // (Boolean) whether to reconnect automatically (false)
+  // reconnectionAttempts: 5, // (Number) number of reconnection attempts before giving up (Infinity),
+  reconnectionDelay: 3000, // (Number) how long to initially wait before attempting a new (1000) }
+});
+app.use(store);
+app.use(router);
+app.mount('#app');
 
-export default app
+export default app;

--- a/axolotl-web/src/pages/About.vue
+++ b/axolotl-web/src/pages/About.vue
@@ -1,15 +1,14 @@
 <template>
   <component :is="$route.meta.layout || 'div'">
     <div class="about">
-      <img class="logo" src="/axolotl.png" alt="Axolotl logo">
+      <img class="logo" src="/axolotl.png" alt="Axolotl logo" />
       <h1 class="title">Axolotl Beta {{ config.Version }}</h1>
       <h2 v-translate class="subtitle">A cross-platform Signal client</h2>
       <div class="description">
         <translate>
-          This is a free and open source Signal client written in golang, rust and
-          vuejs.
+          This is a free and open source Signal client written in golang, rust and vuejs.
         </translate>
-        <br>
+        <br />
         <translate class="mr-1">
           You can support the development of Axolotl either by filling
         </translate>
@@ -17,41 +16,44 @@
           v-translate
           href="https://github.com/nanu-c/axolotl/issues"
           @click="openExternal($event, 'https://github.com/nanu-c/axolotl/issues')"
-        >issues at the bug tracker</a>.
-        <br>
+        >
+          issues at the bug tracker
+        </a>
+        .
+        <br />
         <translate class="mr-1">or by becoming a</translate>
         <a
           href="https://www.patreon.com/bePatron?u=11219559"
-          @click="
-            openExternal($event, 'https://www.patreon.com/bePatron?u=11219559')
-          "
-        ><span v-translate>sponsor on patreon.</span></a><br>
-        <br>
+          @click="openExternal($event, 'https://www.patreon.com/bePatron?u=11219559')"
+        >
+          <span v-translate>sponsor on patreon.</span>
+        </a>
+        <br />
+        <br />
         <font-awesome-icon id="heart" icon="heart" />
-        <br>
-        <a
-          href="https://axolotl.chat"
-          @click="openExternal($event, 'https://axolotl.chat')"
-        >https://axolotl.chat</a>
+        <br />
+        <a href="https://axolotl.chat" @click="openExternal($event, 'https://axolotl.chat')">
+          https://axolotl.chat
+        </a>
       </div>
     </div>
   </component>
 </template>
 
 <script>
-import { mapState } from "vuex";
+import { mapState } from 'vuex';
 export default {
-  name: "AboutPage",
+  name: 'AboutPage',
   components: {},
   data() {
     return {
       showConfirmationModal: false,
     };
   },
-  computed: mapState(["config", "gui"]),
+  computed: mapState(['config', 'gui']),
   methods: {
     openExternal(e, url) {
-      if (this.gui === "ut") {
+      if (this.gui === 'ut') {
         e.preventDefault();
         alert(url);
       }

--- a/axolotl-web/src/pages/ChatList.vue
+++ b/axolotl-web/src/pages/ChatList.vue
@@ -9,9 +9,7 @@
       >
         Contacts
       </router-link>
-      <router-link v-translate class="dropdown-item" :to="'/settings/'">
-        Settings
-      </router-link>
+      <router-link v-translate class="dropdown-item" :to="'/settings/'">Settings</router-link>
     </template>
     <div v-if="chatList" class="chatList">
       <div v-if="editActive" class="actions-header">
@@ -32,7 +30,7 @@
           :id="chat.id.Contact ? chat.id.Contact : chat.id.Group"
           :class="
             editActive &&
-              selectedChat.indexOf(chat.id.Contact ? chat.id.Contact : chat.id.Group) >= 0
+            selectedChat.indexOf(chat.id.Contact ? chat.id.Contact : chat.id.Group) >= 0
               ? 'selected col-12 chat-container'
               : 'col-12 chat-container '
           "
@@ -63,21 +61,13 @@
               <div class="row">
                 <div class="col-9">
                   <div class="name">
-                    <font-awesome-icon
-                      v-if="chat.muted"
-                      class="mute"
-                      icon="volume-mute"
-                    />
+                    <font-awesome-icon v-if="chat.muted" class="mute" icon="volume-mute" />
                     <font-awesome-icon
                       v-if="chat.is_group"
                       class="is_group me-1"
                       icon="user-friends"
                     />
-                    <div
-                      v-if="chat.is_group && chat.title === ''"
-                      v-translate
-                      class="title"
-                    >
+                    <div v-if="chat.is_group && chat.title === ''" v-translate class="title">
                       Unknown group
                     </div>
                     <div v-else class="title">
@@ -113,9 +103,7 @@
           </div>
         </div>
       </div>
-      <div v-if="chatList.length === 0" v-translate class="no-entries">
-        No chats available
-      </div>
+      <div v-if="chatList.length === 0" v-translate class="no-entries">No chats available</div>
       <router-link v-if="config?.contacts" :to="'/contacts/'" class="btn start-chat">
         <font-awesome-icon icon="pencil-alt" />
       </router-link>
@@ -124,99 +112,99 @@
 </template>
 
 <script>
-import moment from 'moment'
-import { mapState } from 'vuex'
-import { router } from '@/router/router'
-import config from '@/config.js'
-import { ref } from 'vue'
+import moment from 'moment';
+import { mapState } from 'vuex';
+import { router } from '@/router/router';
+import config from '@/config.js';
+import { ref } from 'vue';
 
 export default {
   name: 'ChatList',
   setup() {
-    const globalConfig = ref(config)
-    return { globalConfig }
+    const globalConfig = ref(config);
+    return { globalConfig };
   },
   data() {
     return {
       editActive: false,
       editWasActive: false,
       selectedChat: [],
-    }
+    };
   },
   computed: {
     ...mapState(['chatList', 'lastMessages', 'sessionNames']),
     chats() {
-      return this.chatList
+      return this.chatList;
     },
   },
   created() {},
   mounted() {
-    document.body.scrollTop = 0
-    document.documentElement.scrollTop = 0
-    this.$language.current = navigator.language || navigator.userLanguage
-    this.$store.dispatch('leaveChat')
-    this.$store.dispatch('clearMessageList')
-    this.$store.dispatch('clearFilterContacts')
-    this.$store.dispatch('getConfig')
-    if (this.$store.state.contacts.length === 0) this.$store.dispatch('getContacts')
-    this.$store.dispatch('getChatList')
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+    this.$language.current = navigator.language || navigator.userLanguage;
+    this.$store.dispatch('leaveChat');
+    this.$store.dispatch('clearMessageList');
+    this.$store.dispatch('clearFilterContacts');
+    this.$store.dispatch('getConfig');
+    if (this.$store.state.contacts.length === 0) this.$store.dispatch('getContacts');
+    this.$store.dispatch('getChatList');
   },
   methods: {
     humanifyDate(inputDate) {
-      moment.locale(this.$language.current)
-      const date = new moment(inputDate)
-      const min = moment().diff(date, 'minutes')
+      moment.locale(this.$language.current);
+      const date = new moment(inputDate);
+      const min = moment().diff(date, 'minutes');
       if (min < 60) {
-        if (min === 0) return 'now'
-        return moment().diff(date, 'minutes') + ' min'
+        if (min === 0) return 'now';
+        return moment().diff(date, 'minutes') + ' min';
       }
-      const hours = moment().diff(date, 'hours')
-      if (hours < 24) return hours + ' h'
-      return date.format('DD. MMM')
+      const hours = moment().diff(date, 'hours');
+      if (hours < 24) return hours + ' h';
+      return date.format('DD. MMM');
     },
     editChat(e) {
-      this.selectedChat.push(e)
-      this.editActive = true
+      this.selectedChat.push(e);
+      this.editActive = true;
     },
     editDeactivate(e) {
-      this.editActive = false
-      e.preventDefault()
-      e.stopPropagation()
-      this.editWasActive = true
-      this.selectedChat = []
+      this.editActive = false;
+      e.preventDefault();
+      e.stopPropagation();
+      this.editWasActive = true;
+      this.selectedChat = [];
     },
     delChat(e) {
-      this.editActive = false
-      e.preventDefault()
-      e.stopPropagation()
+      this.editActive = false;
+      e.preventDefault();
+      e.stopPropagation();
       if (this.selectedChat.length > 0) {
         this.selectedChat.forEach((c) => {
-          this.$store.dispatch('delChat', c)
-        })
+          this.$store.dispatch('delChat', c);
+        });
       }
-      this.editWasActive = true
-      this.selectedChat = []
+      this.editWasActive = true;
+      this.selectedChat = [];
     },
     onImageError(event) {
-      event.target.style.display = 'none'
+      event.target.style.display = 'none';
     },
     isGroupCheck(e) {
       if (e.DirectMessageRecipientID === -1) {
-        return true
+        return true;
       } else {
-        return false
+        return false;
       }
     },
     enterChat(chat) {
       if (!this.editActive) {
         // this.$store.dispatch("setCurrentChat", chat);
-        router.push(`/chat/${JSON.stringify(chat.id)}`)
+        router.push(`/chat/${JSON.stringify(chat.id)}`);
       } else {
-        this.selectedChat.push(chat.Tel)
+        this.selectedChat.push(chat.Tel);
       }
     },
   },
-}
+};
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/axolotl-web/src/pages/Contacts.vue
+++ b/axolotl-web/src/pages/Contacts.vue
@@ -18,24 +18,15 @@
           <font-awesome-icon icon="times" @click="closeActionMode()" />
         </button>
       </div>
-      <div v-if="contacts.length === 0" v-translate class="empty">
-        Contact list is empty...
-      </div>
+      <div v-if="contacts.length === 0" v-translate class="empty">Contact list is empty...</div>
       <div v-if="contactsFilterActive">
         <div
           v-for="c in contactsFiltered"
           :key="c.Tel"
-          :class="
-            c === selectedContact
-              ? 'selected btn col-12 chat'
-              : 'btn col-12 chat'
-          "
+          :class="c === selectedContact ? 'selected btn col-12 chat' : 'btn col-12 chat'"
         >
           <div class="row chat-entry">
-            <div
-              :class="'avatar col-3 ' + checkForUUIDClass(c)"
-              @click="contactClick(c)"
-            >
+            <div :class="'avatar col-3 ' + checkForUUIDClass(c)" @click="contactClick(c)">
               <div class="badge-name">
                 <img
                   class="avatar-img"
@@ -60,15 +51,10 @@
         v-for="c in contacts"
         v-else
         :key="c.uuid"
-        :class="
-          c === selectedContact ? 'selected btn col-12 chat' : 'btn col-12 chat'
-        "
+        :class="c === selectedContact ? 'selected btn col-12 chat' : 'btn col-12 chat'"
       >
         <div class="row chat-entry">
-          <div
-            :class="'avatar col-3 avatar ' + checkForUUIDClass(c)"
-            @click="contactClick(c)"
-          >
+          <div :class="'avatar col-3 avatar ' + checkForUUIDClass(c)" @click="contactClick(c)">
             <div class="badge-name">
               <img
                 class="avatar-img"
@@ -81,7 +67,7 @@
           </div>
           <div class="meta col-8" @click="contactClick(c)">
             <p class="name">{{ c.name }}</p>
-            <p v-if="c.phonenumber" class="number">{{ `+${ c.phonenumber}` }}</p>
+            <p v-if="c.phonenumber" class="number">{{ `+${c.phonenumber}` }}</p>
           </div>
           <!-- <div class="col-1" @click="showContactAction(c)">
             <font-awesome-icon icon="wrench" />
@@ -90,10 +76,7 @@
       </div>
 
       <div v-if="addContactModal" class="addContactModal">
-        <add-contact-modal
-          @close="closeAddContactModal()"
-          @add="addContact($event)"
-        />
+        <add-contact-modal @close="closeAddContactModal()" @add="addContact($event)" />
       </div>
       <div v-if="editContactModal" class="editContactModal">
         <edit-contact-modal
@@ -110,12 +93,12 @@
 </template>
 
 <script>
-import AddContactModal from "@/components/AddContactModal.vue";
-import EditContactModal from "@/components/EditContactModal.vue";
-import { validateUUID } from "@/helpers/uuidCheck";
+import AddContactModal from '@/components/AddContactModal.vue';
+import EditContactModal from '@/components/EditContactModal.vue';
+import { validateUUID } from '@/helpers/uuidCheck';
 
 export default {
-  name: "ContactsPage",
+  name: 'ContactsPage',
   components: {
     AddContactModal,
     EditContactModal,
@@ -147,7 +130,7 @@ export default {
     },
   },
   mounted() {
-    this.$store.dispatch("getContacts");
+    this.$store.dispatch('getContacts');
   },
   methods: {
     validateUUID,
@@ -158,7 +141,7 @@ export default {
       this.addContactModal = false;
     },
     addContact(data) {
-      this.$store.dispatch("addContact", data);
+      this.$store.dispatch('addContact', data);
       this.addContactModal = false;
     },
     showContactAction(contact) {
@@ -170,11 +153,11 @@ export default {
       this.selectedContact = null;
     },
     delContact() {
-      this.$store.dispatch("delContact", this.selectedContact.Tel);
+      this.$store.dispatch('delContact', this.selectedContact.Tel);
       this.closeActionMode();
     },
     onImageError(event) {
-      event.target.style.display = "none";
+      event.target.style.display = 'none';
     },
     openEditContactModal() {
       this.editContactModal = true;
@@ -185,23 +168,21 @@ export default {
       this.closeActionMode();
     },
     saveContact(data) {
-      this.$store.dispatch("editContact", data);
+      this.$store.dispatch('editContact', data);
       this.closeEditContactModal();
     },
     contactClick(contact) {
       if (!this.showActions) {
-        if (this.validateUUID(contact.uuid)){
-          this.$router.push(`/chat/${JSON.stringify({Contact:contact.uuid})}`);
-
+        if (this.validateUUID(contact.uuid)) {
+          this.$router.push(`/chat/${JSON.stringify({ Contact: contact.uuid })}`);
         }
-        
       } else {
         this.closeActionMode();
       }
     },
     checkForUUIDClass(contact) {
       var isValid = this.validateUUID(contact.uuid);
-      return isValid ? "" : "not-registered";
+      return isValid ? '' : 'not-registered';
     },
   },
 };
@@ -272,7 +253,7 @@ export default {
     rgb(134, 134, 134) 100%
   );
 }
-  /*
+/*
 .avatar{
   border-radius: 50px;
 background-color: #2090ea;
@@ -284,16 +265,16 @@ display: flex;
 color: #FFF;
 margin:20px;
 } */
-.meta{
+.meta {
   text-align: left;
   display: flex;
   justify-content: center;
   flex-direction: column;
 }
-.meta p{
+.meta p {
   margin: 0;
 }
-.meta .name{
+.meta .name {
   font-size: 16px;
   font-weight: 600;
 }

--- a/axolotl-web/src/pages/Debug.vue
+++ b/axolotl-web/src/pages/Debug.vue
@@ -23,25 +23,25 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
+import { mapState } from 'vuex';
 export default {
-  name: "DebugPage",
+  name: 'DebugPage',
   computed: {
     localRegistrationStatus() {
-      return localStorage.getItem("registrationStatus");
+      return localStorage.getItem('registrationStatus');
     },
-    ...mapState(["registrationStatus"]),
+    ...mapState(['registrationStatus']),
   },
   mounted() {
     // To be sure that this page isn't hidden by the loader
-    let loader = document.getElementById("initial-loader");
+    let loader = document.getElementById('initial-loader');
     if (loader !== undefined) {
       loader.remove();
     }
   },
   methods: {
     clearRegistrationFromLocalStorage() {
-      localStorage.removeItem("registrationStatus");
+      localStorage.removeItem('registrationStatus');
     },
     clearLocalStorage() {
       localStorage.clear();

--- a/axolotl-web/src/pages/DeviceLinking.vue
+++ b/axolotl-web/src/pages/DeviceLinking.vue
@@ -10,19 +10,19 @@
 </template>
 
 <script>
-import QRCode from 'qrcode'
-import { mapState } from 'vuex'
+import QRCode from 'qrcode';
+import { mapState } from 'vuex';
 
 export default {
   name: 'DeviceLinking',
   computed: mapState(['deviceLinkCode']),
   watch: {
     deviceLinkCode() {
-      this.updateQrCode()
+      this.updateQrCode();
     },
   },
   mounted() {
-    this.updateQrCode()
+    this.updateQrCode();
   },
   methods: {
     updateQrCode() {
@@ -35,12 +35,12 @@ export default {
               mode: 'url',
             },
           ],
-          { errorCorrectionLevel: 'L' }
-        )
+          { errorCorrectionLevel: 'L' },
+        );
       }
     },
   },
-}
+};
 </script>
 <style scoped>
 .device-linking-page {

--- a/axolotl-web/src/pages/DeviceList.vue
+++ b/axolotl-web/src/pages/DeviceList.vue
@@ -13,7 +13,7 @@
               </span>
             </div>
           </div>
-          <div v-if="i!== 0" class="col-2 actions">
+          <div v-if="i !== 0" class="col-2 actions">
             <button class="btn" @click="delDevice(device.id)">
               <font-awesome-icon icon="trash" />
             </button>
@@ -24,20 +24,16 @@
       <button class="btn start-chat" @click="linkDevice">
         <font-awesome-icon icon="plus" />
       </button>
-      <add-device-modal
-        v-if="showModal"
-        @close="showModal = false"
-        @add="addDevice($event)"
-      />
+      <add-device-modal v-if="showModal" @close="showModal = false" @add="addDevice($event)" />
     </div>
   </component>
 </template>
 
 <script>
-import AddDeviceModal from "@/components/AddDeviceModal";
+import AddDeviceModal from '@/components/AddDeviceModal';
 
 export default {
-  name: "DeviceList",
+  name: 'DeviceList',
   components: {
     AddDeviceModal,
   },
@@ -52,46 +48,46 @@ export default {
     },
   },
   mounted() {
-    this.$store.dispatch("getDevices");
+    this.$store.dispatch('getDevices');
   },
   methods: {
     linkDevice() {
-      if (this.gui === "ut") {
-        const result = window.prompt("desktopLink");
+      if (this.gui === 'ut') {
+        const result = window.prompt('desktopLink');
         this.showSettingsMenu = false;
-        this.$store.dispatch("addDevice", result);
+        this.$store.dispatch('addDevice', result);
       } else {
         this.showModal = true;
       }
     },
     addDevice(qr) {
       this.showModal = false;
-      if (qr !== "") this.$store.dispatch("addDevice", qr);
+      if (qr !== '') this.$store.dispatch('addDevice', qr);
     },
     delDevice(id) {
-      this.$store.dispatch("delDevice", id);
+      this.$store.dispatch('delDevice', id);
     },
     humanifyDate(inputDate) {
       const now = new Date();
       const date = new Date(inputDate);
       const diff = (now - date) / 1000;
       const seconds = diff;
-      if (seconds < 60) return "now";
+      if (seconds < 60) return 'now';
       const minutes = seconds / 60;
-      if (minutes < 60) return Math.floor(minutes) + " minutes ago";
+      if (minutes < 60) return Math.floor(minutes) + ' minutes ago';
       const hours = minutes / 60;
-      if (hours < 24) return Math.floor(hours) + " hours ago";
+      if (hours < 24) return Math.floor(hours) + ' hours ago';
       return (
         date.getFullYear() +
-        "-" +
+        '-' +
         (date.getMonth() + 1) +
-        "-" +
+        '-' +
         date.getDate() +
-        " " +
+        ' ' +
         date.getHours() +
-        ":" +
+        ':' +
         date.getMinutes() +
-        ":" +
+        ':' +
         date.getSeconds()
       );
     },

--- a/axolotl-web/src/pages/EditContact.vue
+++ b/axolotl-web/src/pages/EditContact.vue
@@ -2,11 +2,13 @@
   <component :is="$route.meta.layout || 'div'">
     <template #header>
       <div v-if="profile.Recipient" class="profile-edit-header">
-        <span>{{
-          profile.Recipient.ProfileGivenName !== ""
-            ? profile.Recipient.ProfileGivenName
-            : profile.Recipient.Username
-        }}</span>
+        <span>
+          {{
+            profile.Recipient.ProfileGivenName !== ''
+              ? profile.Recipient.ProfileGivenName
+              : profile.Recipient.Username
+          }}
+        </span>
       </div>
     </template>
     <div v-translate class="mt-4">Update name for contact</div>
@@ -25,7 +27,7 @@
 export default {
   data() {
     return {
-      name: "",
+      name: '',
     };
   },
   computed: {
@@ -47,7 +49,7 @@ export default {
       }
     },
     save() {
-      this.$store.dispatch("updateProfileName", {
+      this.$store.dispatch('updateProfileName', {
         id: this.profile.Recipient.Id,
         name: this.name,
       });

--- a/axolotl-web/src/pages/EditGroup.vue
+++ b/axolotl-web/src/pages/EditGroup.vue
@@ -11,14 +11,16 @@
             class="form-control"
             placeholder="Enter group name"
             @change="setGroupName"
-          >
+          />
         </div>
         <p v-translate>Note, you can't add yourself to a group.</p>
         <button class="btn add-group-members" @click="addMembersModal = true">
-          <font-awesome-icon v-translate icon="plus" /> Members
+          <font-awesome-icon v-translate icon="plus" />
+          Members
         </button>
         <button class="btn create-group" @click="updateGroup">
-          <font-awesome-icon v-translate icon="check" /> Update group
+          <font-awesome-icon v-translate icon="check" />
+          Update group
         </button>
         <add-group-members-modal
           v-if="addMembersModal"
@@ -58,11 +60,11 @@
 </template>
 
 <script>
-import AddGroupMembersModal from "@/components/AddGroupMembersModal.vue";
-import { mapState } from "vuex";
+import AddGroupMembersModal from '@/components/AddGroupMembersModal.vue';
+import { mapState } from 'vuex';
 
 export default {
-  name: "EditGroup",
+  name: 'EditGroup',
   components: {
     AddGroupMembersModal,
   },
@@ -74,10 +76,10 @@ export default {
       creatingGroup: false,
     };
   },
-  computed: mapState(["config", "currentGroup", "contacts"]),
+  computed: mapState(['config', 'currentGroup', 'contacts']),
   mounted() {
-    this.$store.dispatch("getConfig");
-    this.$store.dispatch("getContacts");
+    this.$store.dispatch('getConfig');
+    this.$store.dispatch('getContacts');
   },
   methods: {
     setGroupName() {},
@@ -85,10 +87,7 @@ export default {
       const found = this.newGroupMembers.find(function (element) {
         return element.Tel === groupMember.Tel;
       });
-      if (
-        typeof found === "undefined" &&
-        groupMember.Tel !== this.config.RegisteredNumber
-      )
+      if (typeof found === 'undefined' && groupMember.Tel !== this.config.RegisteredNumber)
         this.newGroupMembers.push(groupMember);
     },
     removeMember(i) {
@@ -108,7 +107,7 @@ export default {
           if (m.Tel !== this.config.RegisteredNumber) members.push(m.Tel);
         });
         if (members.length > 0)
-          this.$store.dispatch("updateGroup", {
+          this.$store.dispatch('updateGroup', {
             name: this.currentGroup.Name,
             members: members,
             id: this.currentGroup.Hexid,

--- a/axolotl-web/src/pages/MessageList.vue
+++ b/axolotl-web/src/pages/MessageList.vue
@@ -1,16 +1,8 @@
 <template>
   <component :is="$route.meta.layout || 'div'">
     <div v-if="currentChat" class="chat">
-      <div
-        id="messageList-container"
-        class="messageList-container"
-        @scroll="handleScroll($event)"
-      >
-        <div
-          v-if="messages && messages.length > 0"
-          id="messageList"
-          class="messageList row"
-        >
+      <div id="messageList-container" class="messageList-container" @scroll="handleScroll($event)">
+        <div v-if="messages && messages.length > 0" id="messageList" class="messageList row">
           <div v-if="showFullscreenImgSrc !== ''" class="fullscreenImage">
             <img
               :src="'http://localhost:9080/attachments/' + showFullscreenImgSrc"
@@ -25,9 +17,7 @@
           </div>
           <div v-if="showFullscreenVideoSrc !== ''" class="fullscreenImage">
             <video controls>
-              <source
-                :src="'http://localhost:9080/attachments/' + showFullscreenVideoSrc"
-              />
+              <source :src="'http://localhost:9080/attachments/' + showFullscreenVideoSrc" />
               <span v-translate>Your browser does not support the audio element.</span>
             </video>
             <button class="btn btn-secondary close" @click="showFullscreenVideoSrc = ''">
@@ -103,17 +93,12 @@
           </div>
         </div>
         <div v-else class="messageInputBox justify-content-center">
-          <div
-            class="messageInput-btn-container d-flex justify-content-center align-items-center"
-          >
+          <div class="messageInput-btn-container d-flex justify-content-center align-items-center">
             <div>
-              <span>{{ Math.floor(voiceNote.duration) }}</span><span v-translate class="me-2">s</span>
+              <span>{{ Math.floor(voiceNote.duration) }}</span>
+              <span v-translate class="me-2">s</span>
             </div>
-            <button
-              v-if="!voiceNote.playing"
-              class="btn send play me-1"
-              @click="playAudio"
-            >
+            <button v-if="!voiceNote.playing" class="btn send play me-1" @click="playAudio">
               <font-awesome-icon icon="play" />
             </button>
             <button v-else class="btn send stop me-1" @click="stopPlayAudio">
@@ -127,14 +112,10 @@
             </button>
           </div>
         </div>
-        <audio
-          v-if="voiceNote.blobUrl !== ''"
-          id="voiceNote"
-          controls
-          :src="voiceNote.blobUrl"
-        >
+        <audio v-if="voiceNote.blobUrl !== ''" id="voiceNote" controls :src="voiceNote.blobUrl">
           Your browser does not support the
-          <code>audio</code> element.
+          <code>audio</code>
+          element.
         </audio>
         <attachment-bar
           v-if="showAttachmentsBar"
@@ -160,12 +141,12 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-import Message from '@/components/Message'
-import AttachmentBar from '@/components/AttachmentBar'
-import DefaultLayout from '@/layouts/Default'
-import { saveAs } from 'file-saver'
-import MicRecorder from '@jmd01/mic-recorder-to-mp3'
+import { mapState } from 'vuex';
+import Message from '@/components/Message';
+import AttachmentBar from '@/components/AttachmentBar';
+import DefaultLayout from '@/layouts/Default';
+import { saveAs } from 'file-saver';
+import MicRecorder from '@jmd01/mic-recorder-to-mp3';
 export default {
   name: 'MessageList',
   components: {
@@ -197,36 +178,36 @@ export default {
         duration: 0,
         firstScroll: true,
       },
-    }
+    };
   },
   computed: {
     messages() {
-      return this.$store.state.messageList
+      return this.$store.state.messageList;
     },
     isGroup() {
-      if (!this.$store.state.currentChat) return false
-      return this.$store.state.currentChat?.thread?.Group !== undefined
+      if (!this.$store.state.currentChat) return false;
+      return this.$store.state.currentChat?.thread?.Group !== undefined;
     },
     ...mapState(['contacts', 'config', 'messageList', 'currentGroup', 'currentChat']),
   },
   watch: {
     messageInput() {
       // Adapt height of the textarea when its content changed
-      let textarea = document.getElementById('messageInput')
-      if (!textarea) return
+      let textarea = document.getElementById('messageInput');
+      if (!textarea) return;
       if (this.messageInput === '') {
-        textarea.style.height = '35px'
+        textarea.style.height = '35px';
       } else {
-        textarea.style.height = 0 // Set height to 0 to reset scrollHeight to its minimum
-        textarea.style.height = textarea.scrollHeight + 5 + 'px'
+        textarea.style.height = 0; // Set height to 0 to reset scrollHeight to its minimum
+        textarea.style.height = textarea.scrollHeight + 5 + 'px';
       }
-      localStorage.setItem(JSON.stringify(this.currentChat.thread), this.messageInput)
+      localStorage.setItem(JSON.stringify(this.currentChat.thread), this.messageInput);
     },
     currentChat: {
       handler() {
-        const savedInput = localStorage.getItem(JSON.stringify(this.currentChat.thread))
-        if (savedInput && savedInput !== null) this.messageInput = savedInput
-        this.scrollDown()
+        const savedInput = localStorage.getItem(JSON.stringify(this.currentChat.thread));
+        if (savedInput && savedInput !== null) this.messageInput = savedInput;
+        this.scrollDown();
       },
       deep: true,
     },
@@ -234,37 +215,37 @@ export default {
       // This will let Vue know to look inside the array
       deep: true,
       handler() {
-        if (!this.$data.scrollLocked) setTimeout(this.scrollDown, 600)
+        if (!this.$data.scrollLocked) setTimeout(this.scrollDown, 600);
         if (!this.$data.firstScroll) {
-          setTimeout((this.$data.scrollLocked = false), 1000)
-        } else this.$data.scrollLocked = false
+          setTimeout((this.$data.scrollLocked = false), 1000);
+        } else this.$data.scrollLocked = false;
 
-        this.$data.firstScroll = false
+        this.$data.firstScroll = false;
         // this.scrollDown();
       },
     },
   },
   mounted() {
-    this.$store.dispatch('openChat', this.getId())
-    const mi = document.getElementById('messageInput')
-    if (mi) mi.focus()
-    setTimeout(this.scrollDown, 600)
+    this.$store.dispatch('openChat', this.getId());
+    const mi = document.getElementById('messageInput');
+    if (mi) mi.focus();
+    setTimeout(this.scrollDown, 600);
   },
   methods: {
     getId: function () {
-      return this.chatId
+      return this.chatId;
     },
     callContentHub(type) {
       if (typeof this.config.feature !== 'undefined' && this.config.feature === 'ut') {
-        const result = window.prompt(type)
-        this.showSettingsMenu = false
+        const result = window.prompt(type);
+        this.showSettingsMenu = false;
         if (result !== 'canceld')
           this.$store.dispatch('sendAttachment', {
             type: type,
             path: result,
             to: this.chatId,
             message: this.messageInput,
-          })
+          });
       } else {
         // this.showSettingsMenu = false;
         // document.getElementById("addVcf").click()
@@ -272,62 +253,62 @@ export default {
     },
     loadAttachmentDialog() {
       if (typeof this.config.feature !== 'undefined' && this.config.feature === 'ut') {
-        this.showAttachmentsBar = true
+        this.showAttachmentsBar = true;
       } else {
-        document.getElementById('attachment').click()
+        document.getElementById('attachment').click();
       }
     },
     sendDesktopAttachment(evt) {
-      const file = evt.target.files[0]
+      const file = evt.target.files[0];
       if (file) {
-        const reader = new FileReader()
-        const that = this
+        const reader = new FileReader();
+        const that = this;
         reader.onload = function (e) {
-          const attachment = e.target.result
+          const attachment = e.target.result;
           that.$store.dispatch('uploadAttachment', {
             attachment: attachment,
             to: that.chatId,
             message: this.messageInput,
-          })
-        }
-        reader.readAsDataURL(file)
+          });
+        };
+        reader.readAsDataURL(file);
       } else {
-        alert('Failed to load file')
+        alert('Failed to load file');
       }
     },
     showFullscreenImg(img) {
-      this.showFullscreenImgSrc = img
+      this.showFullscreenImgSrc = img;
     },
     showFullscreenVideo(video) {
-      this.showFullscreenVideoSrc = video
+      this.showFullscreenVideoSrc = video;
     },
     saveImg(e) {
       if (typeof this.config.feature !== 'undefined' && this.config.feature === 'ut') {
-        e.preventDefault()
-        alert('[oP]' + this.showFullscreenImgSrc)
-      } else saveAs(`http://localhost:9080/attachments/${this.showFullscreenImgSrc}`)
+        e.preventDefault();
+        alert('[oP]' + this.showFullscreenImgSrc);
+      } else saveAs(`http://localhost:9080/attachments/${this.showFullscreenImgSrc}`);
     },
     saveVideo(e) {
       if (typeof this.config.feature !== 'undefined' && this.config.feature === 'ut') {
-        e.preventDefault()
-        alert('[oV]' + this.showFullscreenVideoSrc)
-      } else saveAs(`http://localhost:9080/attachments/${this.showFullscreenVideoSrc}`)
+        e.preventDefault();
+        alert('[oV]' + this.showFullscreenVideoSrc);
+      } else saveAs(`http://localhost:9080/attachments/${this.showFullscreenVideoSrc}`);
     },
     sendMessage() {
       if (this.messageInput !== '') {
         this.$store.dispatch('sendMessage', {
           to: this.chatId,
           message: this.messageInput,
-        })
+        });
         if (this.$store.state.messageList === null) {
-          this.$store.dispatch('getMessageList', this.getId())
+          this.$store.dispatch('getMessageList', this.getId());
         }
-        this.messageInput = ''
+        this.messageInput = '';
       }
-      this.scrollDown()
+      this.scrollDown();
     },
     joinGroupAccept() {
-      this.$store.dispatch('joinGroup', this.chat.UUID)
+      this.$store.dispatch('joinGroup', this.chat.UUID);
     },
     handleScroll(event) {
       if (
@@ -336,31 +317,27 @@ export default {
         this.$store.state.messageList &&
         this.$store.state.messageList.length > 19
       ) {
-        this.$data.scrollLocked = true
-        this.$store.dispatch('getMoreMessages')
+        this.$data.scrollLocked = true;
+        this.$store.dispatch('getMoreMessages');
       }
     },
     back() {
-      this.$router.go(-1)
+      this.$router.go(-1);
     },
     paste() {
       if (typeof this.config.feature !== 'undefined' && this.config.feature === 'ut') {
         // Don't follow the link
-        const result = window.prompt('paste')
-        this.messageInput = this.messageInput + result
+        const result = window.prompt('paste');
+        this.messageInput = this.messageInput + result;
       }
     },
     scrollDown() {
-      if (
-        this.messages &&
-        this.messages.length !== 0 &&
-        document.getElementById('chat-bottom')
-      )
-        document.getElementById('chat-bottom').scrollIntoView()
+      if (this.messages && this.messages.length !== 0 && document.getElementById('chat-bottom'))
+        document.getElementById('chat-bottom').scrollIntoView();
     },
     recordAudio() {
-      var that = this
-      this.voiceNote.playing = false
+      var that = this;
+      this.voiceNote.playing = false;
       navigator.mediaDevices
         .getUserMedia({
           video: false,
@@ -369,82 +346,82 @@ export default {
         .then(async function () {
           that.voiceNote.recorder = new MicRecorder({
             bitRate: 128,
-          })
+          });
           that.voiceNote.recorder
             .start()
             .then(() => {
               // something else
-              that.voiceNote.recording = true
+              that.voiceNote.recording = true;
             })
             .catch((e) => {
               //skipqc: JS-0002
               /* eslint-disable no-console */
-              console.error(e)
-            })
-        })
+              console.error(e);
+            });
+        });
     },
     deleteAudio() {
-      this.stopPlayAudio()
-      this.voiceNote.playing = false
-      this.voiceNote.recorded = false
-      this.voiceNote.recorder = null
+      this.stopPlayAudio();
+      this.voiceNote.playing = false;
+      this.voiceNote.recorded = false;
+      this.voiceNote.recorder = null;
     },
     playAudio() {
-      this.voiceNote.playing = true
-      this.voiceNote.voiceNoteElem.play()
+      this.voiceNote.playing = true;
+      this.voiceNote.voiceNoteElem.play();
     },
     stopPlayAudio() {
-      this.voiceNote.playing = false
-      this.voiceNote.voiceNoteElem.pause()
+      this.voiceNote.playing = false;
+      this.voiceNote.voiceNoteElem.pause();
     },
     stopRecording() {
-      this.voiceNote.recording = false
-      this.voiceNote.recorded = true
-      this.voiceNote.recorder.stop()
+      this.voiceNote.recording = false;
+      this.voiceNote.recorded = true;
+      this.voiceNote.recorder.stop();
       this.voiceNote.recorder.getMp3().then(([, blob]) => {
-        this.voiceNote.blobUrl = URL.createObjectURL(blob)
-        this.voiceNote.blobObj = blob
-        let that = this
+        this.voiceNote.blobUrl = URL.createObjectURL(blob);
+        this.voiceNote.blobObj = blob;
+        let that = this;
         setTimeout(function () {
-          that.voiceNote.voiceNoteElem = document.getElementById('voiceNote')
-          that.voiceNote.duration = that.voiceNote.voiceNoteElem.duration
-        }, 200)
-      })
+          that.voiceNote.voiceNoteElem = document.getElementById('voiceNote');
+          that.voiceNote.duration = that.voiceNote.voiceNoteElem.duration;
+        }, 200);
+      });
     },
     sendVoiceNote() {
-      this.voiceNote.recorded = false
-      let reader = new FileReader()
-      this.voiceNote.voiceNoteElem.pause()
-      this.voiceNote.playing = false
+      this.voiceNote.recorded = false;
+      let reader = new FileReader();
+      this.voiceNote.voiceNoteElem.pause();
+      this.voiceNote.playing = false;
       /* eslint-disable no-unused-vars */
       this.voiceNote.recorder.getMp3().then(() => {
         const file = new File([this.voiceNote.blobObj], 'voice.mp3', {
           type: 'audio/mpeg',
           lastModified: Date.now(),
-        })
-        reader.readAsDataURL(file) // converts the blob to base64 and calls onload
-        var that = this
+        });
+        reader.readAsDataURL(file); // converts the blob to base64 and calls onload
+        var that = this;
         reader.onload = function () {
-          var result = reader.result
+          var result = reader.result;
           const message = {
             note: result,
             to: that.chatId,
-          }
-          that.$store.dispatch('sendVoiceNote', message)
-        }
-      })
+          };
+          that.$store.dispatch('sendVoiceNote', message);
+        };
+      });
     },
     handleClick(event) {
       // If the clicked element doesn't have the right selector, bail
-      if (!event.target.matches('.linkified')) return
+      if (!event.target.matches('.linkified')) return;
       if (typeof this.config.feature !== 'undefined' && this.config.feature === 'ut') {
         // Don't follow the link
-        event.preventDefault()
-        alert(event.target.href)
+        event.preventDefault();
+        alert(event.target.href);
       }
     },
   },
-}
+};
 </script>
 
 <style scoped>
@@ -467,7 +444,9 @@ export default {
 .messageList-container {
   overflow-x: hidden;
   overflow-y: scroll;
-  transition: width 0.5s, height 0.5s;
+  transition:
+    width 0.5s,
+    height 0.5s;
   padding-top: 5px;
 }
 

--- a/axolotl-web/src/pages/NewGroup.vue
+++ b/axolotl-web/src/pages/NewGroup.vue
@@ -11,14 +11,16 @@
             class="form-control"
             placeholder="Enter group name"
             @change="setGroupName"
-          >
+          />
         </div>
         <p v-translate>Note, you can't add yourself to a group.</p>
         <button class="btn add-group-members" @click="addMembersModal = true">
-          <font-awesome-icon icon="plus" /> <span v-translate>Members</span>
+          <font-awesome-icon icon="plus" />
+          <span v-translate>Members</span>
         </button>
         <button class="btn create-group" @click="createGroup">
-          <font-awesome-icon icon="check" /> <span v-translate>Create group</span>
+          <font-awesome-icon icon="check" />
+          <span v-translate>Create group</span>
         </button>
         <add-group-members-modal
           v-if="addMembersModal"
@@ -48,11 +50,11 @@
 </template>
 
 <script>
-import AddGroupMembersModal from "@/components/AddGroupMembersModal.vue";
-import { mapState } from "vuex";
+import AddGroupMembersModal from '@/components/AddGroupMembersModal.vue';
+import { mapState } from 'vuex';
 
 export default {
-  name: "NewGroup",
+  name: 'NewGroup',
   components: {
     AddGroupMembersModal,
   },
@@ -64,10 +66,10 @@ export default {
       creatingGroup: false,
     };
   },
-  computed: mapState(["config"]),
+  computed: mapState(['config']),
   mounted() {
-    this.$store.dispatch("getConfig");
-    this.$store.dispatch("getContacts");
+    this.$store.dispatch('getConfig');
+    this.$store.dispatch('getContacts');
   },
   methods: {
     setGroupName() {},
@@ -75,10 +77,7 @@ export default {
       const found = this.newGroupMembers.find(function (element) {
         return element.Tel === groupMember.Tel;
       });
-      if (
-        typeof found === "undefined" &&
-        groupMember.Tel !== this.config.RegisteredNumber
-      )
+      if (typeof found === 'undefined' && groupMember.Tel !== this.config.RegisteredNumber)
         this.newGroupMembers.push(groupMember);
     },
     removeMember(i) {
@@ -94,7 +93,7 @@ export default {
           if (m.Tel !== this.config.RegisteredNumber) members.push(m.Tel);
         });
         if (members.length > 0)
-          this.$store.dispatch("createNewGroup", {
+          this.$store.dispatch('createNewGroup', {
             name: this.newGroupName,
             members: members,
           });

--- a/axolotl-web/src/pages/OnBoarding.vue
+++ b/axolotl-web/src/pages/OnBoarding.vue
@@ -50,19 +50,19 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-import config from '@/config.js'
-import { ref } from 'vue'
+import { mapState } from 'vuex';
+import config from '@/config.js';
+import { ref } from 'vue';
 
 export default {
   name: 'OnBoarding',
   components: {},
   setup() {
-    const globalConfig = ref(config)
-    return { globalConfig }
+    const globalConfig = ref(config);
+    return { globalConfig };
   },
   data() {
-    return {}
+    return {};
   },
   computed: mapState([
     'gui',
@@ -73,32 +73,32 @@ export default {
     'registrationError',
   ]),
   mounted() {
-    const userLang = navigator.language || navigator.userLanguage
-    this.$language.current = userLang
+    const userLang = navigator.language || navigator.userLanguage;
+    this.$language.current = userLang;
     if (this.captchaToken !== null && !this.captchaTokenSent) {
-      this.$store.dispatch('sendCaptchaToken')
+      this.$store.dispatch('sendCaptchaToken');
     }
   },
   methods: {
     updatePhone(e) {
-      if (typeof e === 'string') this.phone = e
+      if (typeof e === 'string') this.phone = e;
     },
     openExtern(e, url) {
       if (this.gui === 'ut') {
-        e.preventDefault()
+        e.preventDefault();
         // eslint-disable-next-line no-alert
-        alert(url)
+        alert(url);
       }
     },
     registerAsSecondaryDevice() {
-      this.$store.dispatch('registerSecondaryDevice')
-      this.$router.push('/qr')
+      this.$store.dispatch('registerSecondaryDevice');
+      this.$router.push('/qr');
     },
     register() {
-      window.location = 'https://signalcaptchas.org/registration/generate.html'
+      window.location = 'https://signalcaptchas.org/registration/generate.html';
     },
   },
-}
+};
 </script>
 <style scoped>
 .info,

--- a/axolotl-web/src/pages/Password.vue
+++ b/axolotl-web/src/pages/Password.vue
@@ -1,19 +1,15 @@
 <template>
   <component :is="$route.meta.layout || 'div'">
     <div class="password">
-      <div v-if="error" v-translate class="alert alert-danger">
-        Password is wrong
-      </div>
+      <div v-if="error" v-translate class="alert alert-danger">Password is wrong</div>
       <input
         id="passwordInput"
         v-model="pw"
         type="password"
         class="codeInput form-control"
         @keydown="checkEnter($event)"
-      >
-      <button v-translate class="btn btn-primary" @click="sendPassword">
-        Decrypt
-      </button>
+      />
+      <button v-translate class="btn btn-primary" @click="sendPassword">Decrypt</button>
       <button v-if="error" v-translate class="btn btn-danger" @click="unregister">
         Unregister
       </button>
@@ -22,34 +18,34 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
+import { mapState } from 'vuex';
 
 export default {
-  name: "PasswordPage",
+  name: 'PasswordPage',
   data() {
     return {
-      pw: "",
+      pw: '',
     };
   },
   computed: {
-    ...mapState(["registrationStatus"]),
+    ...mapState(['registrationStatus']),
     error() {
       return this.$store.state.loginError;
     },
   },
   mounted() {
-    document.getElementById("passwordInput").focus();
+    document.getElementById('passwordInput').focus();
   },
   methods: {
     sendPassword() {
-      this.$store.dispatch("sendPassword", this.pw);
+      this.$store.dispatch('sendPassword', this.pw);
       this.pw = null;
     },
     checkEnter(e) {
       if (e.keyCode === 13) this.sendPassword();
     },
     unregister() {
-      this.$store.dispatch("unregister");
+      this.$store.dispatch('unregister');
     },
   },
 };

--- a/axolotl-web/src/pages/Profile.vue
+++ b/axolotl-web/src/pages/Profile.vue
@@ -28,9 +28,8 @@
           <a
             href="tel:{{ `+${profile?.phone_number.code.value}${profile?.phone_number.national.value}` }}"
           >
-            {{
-              `+${profile?.phone_number.code.value}${profile?.phone_number.national.value}`
-            }}</a>
+            {{ `+${profile?.phone_number.code.value}${profile?.phone_number.national.value}` }}
+          </a>
         </div>
         <div v-if="profile?.username !== ''" class="username">
           {{ profile?.username }}
@@ -67,26 +66,26 @@ export default {
   }),
   computed: {
     profile() {
-      return this.$store.state.profile
+      return this.$store.state.profile;
     },
   },
   mounted() {
-    this.$store.dispatch('getProfile', this.profileId)
+    this.$store.dispatch('getProfile', this.profileId);
   },
   methods: {
     onImageError(event) {
-      this.hasProfileImage = false
+      this.hasProfileImage = false;
     },
     editContact() {
       this.$router.push({
         name: 'editContact',
-      })
+      });
     },
     createChat() {
-      this.$router.push(`/chat/${JSON.stringify({ Contact: this.profileId })}`)
+      this.$router.push(`/chat/${JSON.stringify({ Contact: this.profileId })}`);
     },
   },
-}
+};
 </script>
 
 <style scoped>

--- a/axolotl-web/src/pages/Register.vue
+++ b/axolotl-web/src/pages/Register.vue
@@ -12,12 +12,7 @@
         </div>
       </div>
       <div v-else class="registration">
-        <VueTelInput
-          id="phoneInput"
-          mode="international"
-          class="phoneInput"
-          @input="updatePhone"
-        />
+        <VueTelInput id="phoneInput" mode="international" class="phoneInput" @input="updatePhone" />
         <button v-translate class="btn btn-primary mt-3" @click="requestCode()">
           Request code
         </button>
@@ -27,45 +22,44 @@
 </template>
 
 <script>
-import { VueTelInput } from "vue3-tel-input";
-import "vue3-tel-input/dist/vue3-tel-input.css";
-import { mapState } from "vuex";
+import { VueTelInput } from 'vue3-tel-input';
+import 'vue3-tel-input/dist/vue3-tel-input.css';
+import { mapState } from 'vuex';
 
 export default {
-  name: "RegisterPage",
+  name: 'RegisterPage',
   components: {
     VueTelInput,
   },
   data() {
     return {
-      phone: "",
+      phone: '',
     };
   },
   computed: mapState([
-    "gui",
-    "rateLimitError",
-    "registrationStatus",
-    "captchaToken",
-    "captchaTokenSent",
-    "registrationError"
+    'gui',
+    'rateLimitError',
+    'registrationStatus',
+    'captchaToken',
+    'captchaTokenSent',
+    'registrationError',
   ]),
   mounted() {
     const userLang = navigator.language || navigator.userLanguage;
     this.$language.current = userLang;
     if (this.captchaToken !== null && !this.captchaTokenSent) {
-      this.$store.dispatch("sendCaptchaToken");
+      this.$store.dispatch('sendCaptchaToken');
     }
   },
   methods: {
     requestCode() {
-      this.$store.dispatch("requestCode", this.phone.replace(/\s/g, ""));
+      this.$store.dispatch('requestCode', this.phone.replace(/\s/g, ''));
     },
     updatePhone(e) {
-      if(typeof e === "string")
-      this.phone = e;
+      if (typeof e === 'string') this.phone = e;
     },
     openExtern(e, url) {
-      if (this.gui === "ut") {
+      if (this.gui === 'ut') {
         e.preventDefault();
         alert(url);
       }
@@ -102,7 +96,7 @@ h2 {
   max-width: 300px;
   margin: auto;
   margin-top: auto;
-  color: #FFF;
+  color: #fff;
 }
 .logo {
   margin: 20px auto;

--- a/axolotl-web/src/pages/SetPassword.vue
+++ b/axolotl-web/src/pages/SetPassword.vue
@@ -2,38 +2,19 @@
   <component :is="$route.meta.layout || 'div'">
     <div class="set-password">
       <h5 v-translate>Info</h5>
-      <p v-translate>
-        Setting a password is not advised on devices short in memory.
-      </p>
+      <p v-translate>Setting a password is not advised on devices short in memory.</p>
       <p v-translate>Restart is required!</p>
-      <div
-        v-if="passwordError"
-        v-translate
-        class="alert alert-danger"
-        role="alert"
-      >
+      <div v-if="passwordError" v-translate class="alert alert-danger" role="alert">
         Passwords don't match
       </div>
-      <div
-        v-if="passwordUnsafe"
-        v-translate
-        class="alert alert-danger"
-        role="alert"
-      >
+      <div v-if="passwordUnsafe" v-translate class="alert alert-danger" role="alert">
         Unsafe password
       </div>
-      <div
-        v-if="currentPasswordWrong"
-        v-translate
-        class="alert alert-danger"
-        role="alert"
-      >
+      <div v-if="currentPasswordWrong" v-translate class="alert alert-danger" role="alert">
         Current password is wrong
       </div>
       <div class="form-group">
-        <label v-translate for="passwordRepeat" class="text-primary">
-          New password
-        </label>
+        <label v-translate for="passwordRepeat" class="text-primary">New password</label>
         <input
           id="setPassword"
           v-model="password"
@@ -41,12 +22,10 @@
           name="password"
           class="form-control"
           :secure-length="7"
-        >
+        />
       </div>
       <div class="form-group">
-        <label v-translate for="passwordRepeat" class="text-primary">
-          Repeat password
-        </label>
+        <label v-translate for="passwordRepeat" class="text-primary">Repeat password</label>
         <input
           id="passwordRepeat"
           v-model="passwordRepeat"
@@ -54,12 +33,10 @@
           type="password"
           name="passwordRepeat"
           class="form-control"
-        >
+        />
       </div>
       <div class="form-group">
-        <label v-translate for="passwordCurrent" class="text-primary">
-          Current password
-        </label>
+        <label v-translate for="passwordCurrent" class="text-primary">Current password</label>
         <input
           id="passwordCurrent"
           v-model="passwordCurrent"
@@ -67,24 +44,22 @@
           type="password"
           name="passwordCurrent"
           class="form-control"
-        >
+        />
       </div>
-      <button v-translate class="btn btn-primary" @click="setPassword()">
-        Set password
-      </button>
+      <button v-translate class="btn btn-primary" @click="setPassword()">Set password</button>
     </div>
   </component>
 </template>
 
 <script>
 export default {
-  name: "SetPassword",
+  name: 'SetPassword',
   components: {},
   data() {
     return {
-      password: "",
-      passwordCurrent: "",
-      currentRepeat: "",
+      password: '',
+      passwordCurrent: '',
+      currentRepeat: '',
       passwordRepeat: null,
       passwordError: false,
       passwordUnsafe: false,
@@ -99,7 +74,7 @@ export default {
       } else if (password.length < 7 && password.length > 0) {
         this.passwordUnsafe = true;
       } else {
-        this.$store.dispatch("setPassword", {
+        this.$store.dispatch('setPassword', {
           pw: this.password,
           cPw: this.passwordCurrent,
         });

--- a/axolotl-web/src/pages/SetUsername.vue
+++ b/axolotl-web/src/pages/SetUsername.vue
@@ -2,41 +2,28 @@
   <component :is="$route.meta.layout || 'div'">
     <div class="set-username">
       <h5 v-translate>Info</h5>
-      <p v-translate>
-        Setting a username is required. Please choose one.
-      </p>
+      <p v-translate>Setting a username is required. Please choose one.</p>
       <div class="form-group">
-        <label v-translate for="username" class="text-primary">
-          Username
-        </label>
-        <input
-          id="username"
-          v-model="username"
-          required
-          type="text"
-          class="form-control"
-        >
+        <label v-translate for="username" class="text-primary">Username</label>
+        <input id="username" v-model="username" required type="text" class="form-control" />
       </div>
-      <button v-translate class="btn btn-primary" @click="setUsername()">
-        Set username
-      </button>
+      <button v-translate class="btn btn-primary" @click="setUsername()">Set username</button>
     </div>
   </component>
 </template>
 
 <script>
 export default {
-  name: "SetUsername",
-  components: {
-  },
+  name: 'SetUsername',
+  components: {},
   data() {
     return {
-      username: "",
+      username: '',
     };
   },
-  mounted(){
-          // To be sure that this page isn't hidden by the loader
-    let loader = document.getElementById("initial-loader");
+  mounted() {
+    // To be sure that this page isn't hidden by the loader
+    let loader = document.getElementById('initial-loader');
     if (loader !== undefined) {
       loader.remove();
     }
@@ -44,10 +31,9 @@ export default {
   methods: {
     setUsername() {
       const { username } = this;
-      if(username!=""){
-        this.$store.dispatch("setUsername", username);
+      if (username != '') {
+        this.$store.dispatch('setUsername', username);
       }
-
     },
   },
 };

--- a/axolotl-web/src/pages/Settings.vue
+++ b/axolotl-web/src/pages/Settings.vue
@@ -56,18 +56,16 @@
         @confirm="unregister"
       />
       <div class="about w-100">
-        <router-link v-translate class="btn btn-primary" :to="'/about'">
-          About Axolotl
-        </router-link>
+        <router-link v-translate class="btn btn-primary" :to="'/about'">About Axolotl</router-link>
       </div>
       <button v-translate class="btn btn-danger" @click="showConfirmationModal = true">
         Unregister
       </button>
       <div class="warning-box">
         <span v-translate>
-          Due to technical limitations, Axolotl doesn't support push notifications. Keep
-          the app open to be notified in real time. In Ubuntu Touch, use UT Tweak Tool to
-          set Axolotl on "Prevent app suspension".
+          Due to technical limitations, Axolotl doesn't support push notifications. Keep the app
+          open to be notified in real time. In Ubuntu Touch, use UT Tweak Tool to set Axolotl on
+          "Prevent app suspension".
         </span>
       </div>
     </div>
@@ -75,8 +73,8 @@
 </template>
 
 <script>
-import ConfirmationModal from '@/components/ConfirmationModal.vue'
-import { mapState } from 'vuex'
+import ConfirmationModal from '@/components/ConfirmationModal.vue';
+import { mapState } from 'vuex';
 export default {
   name: 'SettingsPage',
   components: {
@@ -87,44 +85,44 @@ export default {
       showConfirmationModal: false,
       darkMode: false,
       loglevel: 'info',
-    }
+    };
   },
   computed: mapState(['config']),
   mounted() {
-    this.$store.dispatch('getConfig')
-    this.darkMode = this.getCookie('darkMode') === 'true'
-    this.loglevel = this.config.LogLevel
+    this.$store.dispatch('getConfig');
+    this.darkMode = this.getCookie('darkMode') === 'true';
+    this.loglevel = this.config.LogLevel;
   },
   methods: {
     unregister() {
-      this.$store.dispatch('unregister')
-      localStorage.removeItem('registrationStatus')
+      this.$store.dispatch('unregister');
+      localStorage.removeItem('registrationStatus');
     },
     toggleDarkMode() {
-      let c = this.getCookie('darkMode')
-      if (this.getCookie('darkMode') === 'false') c = true
-      else c = false
-      this.$store.dispatch('setDarkMode', c)
+      let c = this.getCookie('darkMode');
+      if (this.getCookie('darkMode') === 'false') c = true;
+      else c = false;
+      this.$store.dispatch('setDarkMode', c);
     },
     setLogLevel(e) {
-      this.$store.dispatch('setLogLevel', e.target.value)
+      this.$store.dispatch('setLogLevel', e.target.value);
     },
     getCookie(cname) {
-      const name = cname + '='
-      const ca = document.cookie.split(';')
+      const name = cname + '=';
+      const ca = document.cookie.split(';');
       for (let i = 0; i < ca.length; i++) {
-        let c = ca[i]
+        let c = ca[i];
         while (c.charAt(0) === ' ') {
-          c = c.substring(1)
+          c = c.substring(1);
         }
         if (c.indexOf(name) === 0) {
-          return c.substring(name.length, c.length)
+          return c.substring(name.length, c.length);
         }
       }
-      return false
+      return false;
     },
   },
-}
+};
 </script>
 <style scoped>
 .settings {

--- a/axolotl-web/src/pages/Verification.vue
+++ b/axolotl-web/src/pages/Verification.vue
@@ -2,10 +2,7 @@
   <component :is="$route.meta.layout || 'div'">
     <div class="verify">
       <h3 v-translate>Enter your registration pin</h3>
-      <div
-        v-if="verificationError === 'RegistrationLockFailure' || requestPin"
-        class="verify"
-      >
+      <div v-if="verificationError === 'RegistrationLockFailure' || requestPin" class="verify">
         <p v-translate>or disable it on Android/IOs</p>
         <input v-model="pin" type="text" />
         <button v-translate class="btn btn-primary" @click="sendPin()">Send pin</button>
@@ -16,12 +13,7 @@
           :number-of-boxes="6"
           @input-value="updateCode($event)"
         />
-        <button
-          v-translate
-          :disabled="inProgress"
-          class="btn btn-primary"
-          @click="sendCode()"
-        >
+        <button v-translate :disabled="inProgress" class="btn btn-primary" @click="sendCode()">
           Send code
         </button>
       </div>
@@ -38,8 +30,8 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-import VerificationPinInput from '@/components/VerificationPinInput'
+import { mapState } from 'vuex';
+import VerificationPinInput from '@/components/VerificationPinInput';
 export default {
   name: 'VerificationPage',
   components: {
@@ -50,30 +42,30 @@ export default {
       code: '',
       pin: '',
       inProgress: false,
-    }
+    };
   },
   computed: mapState(['verificationError', 'requestPin', 'registrationStatus']),
   mounted() {},
   methods: {
     updateCode(code) {
-      this.code = code
+      this.code = code;
     },
     sendCode() {
       if (this.code.length === 6) {
-        this.$store.dispatch('sendCode', this.code)
-        this.inProgress = true
+        this.$store.dispatch('sendCode', this.code);
+        this.inProgress = true;
       } else {
-        console.error('code not 6 digits')
+        console.error('code not 6 digits');
       }
     },
     sendPin() {
       if (this.code.length === 6) {
-        this.$store.dispatch('sendPin', this.pin)
-        this.inProgress = true
+        this.$store.dispatch('sendPin', this.pin);
+        this.inProgress = true;
       }
     },
   },
-}
+};
 </script>
 <style>
 .verify {

--- a/axolotl-web/src/router/router.js
+++ b/axolotl-web/src/router/router.js
@@ -1,255 +1,267 @@
-import { createRouter, createWebHistory } from 'vue-router'
-import store from '@/store/store'
+import { createRouter, createWebHistory } from 'vue-router';
+import store from '@/store/store';
 import Legacy from '@/layouts/Legacy.vue';
 import Default from '@/layouts/Default.vue';
-
 
 export const router = new createRouter({
   history: createWebHistory(),
   routes: [
     {
-      path: "/",
-      alias: "/chatList",
-      name: "chatList",
+      path: '/',
+      alias: '/chatList',
+      name: 'chatList',
       meta: {
         layout: Default,
         hasMenu: true,
         hasBackButton: false,
       },
-      component: () => import("@/pages/ChatList.vue")
+      component: () => import('@/pages/ChatList.vue'),
     },
     {
-      path: "/chat/:id",
-      name: "chat",
+      path: '/chat/:id',
+      name: 'chat',
       meta: {
         layout: Legacy,
       },
-      props: route => ({
+      props: (route) => ({
         chatId: route.params.id,
       }),
-      component: () => import("@/pages/MessageList.vue")
+      component: () => import('@/pages/MessageList.vue'),
     },
     {
-      path: "/profile/:id",
-      name: "profile",
+      path: '/profile/:id',
+      name: 'profile',
       meta: {
         layout: Default,
         hasMenu: true,
         hasBackButton: true,
       },
-      props: route => ({
+      props: (route) => ({
         profileId: route.params.id,
       }),
-      component: () => import("@/pages/Profile.vue")
+      component: () => import('@/pages/Profile.vue'),
     },
     {
-      path: "/editContact",
-      name: "editContact",
+      path: '/editContact',
+      name: 'editContact',
       meta: {
         layout: Default,
         hasBackButton: true,
       },
-      component: () => import("@/pages/EditContact.vue")
+      component: () => import('@/pages/EditContact.vue'),
     },
     {
       // register page is where the registration starts
-      path: "/register",
-      name: "register",
+      path: '/register',
+      name: 'register',
       meta: {
         layout: Default,
         textCenter: true,
         hasBackButton: true,
       },
-      component: () => import("@/pages/Register.vue")
+      component: () => import('@/pages/Register.vue'),
     },
     {
       // verify page is for entering the sms pin
-      path: "/verify",
-      name: "verify",
+      path: '/verify',
+      name: 'verify',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/Verification.vue")
+      component: () => import('@/pages/Verification.vue'),
     },
     {
       // password page is for entering the password for database decryption
-      path: "/password",
-      name: "password",
+      path: '/password',
+      name: 'password',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/Password.vue")
+      component: () => import('@/pages/Password.vue'),
     },
     {
       // pin page is for entering the signal registration pin. this is currently broken
       // and handled by the verification page
-      path: "/pin",
-      name: "pin",
+      path: '/pin',
+      name: 'pin',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/Verification.vue")
+      component: () => import('@/pages/Verification.vue'),
     },
     {
-      path: "/setPassword",
-      name: "setPassword",
+      path: '/setPassword',
+      name: 'setPassword',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/SetPassword.vue")
+      component: () => import('@/pages/SetPassword.vue'),
     },
     {
-      path: "/setUsername",
-      name: "setUsername",
+      path: '/setUsername',
+      name: 'setUsername',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/SetUsername.vue")
+      component: () => import('@/pages/SetUsername.vue'),
     },
     {
-      path: "/contacts",
-      name: "contacts",
+      path: '/contacts',
+      name: 'contacts',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/Contacts.vue")
+      component: () => import('@/pages/Contacts.vue'),
     },
     {
-      path: "/settings",
-      name: "settings",
+      path: '/settings',
+      name: 'settings',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/Settings.vue")
+      component: () => import('@/pages/Settings.vue'),
     },
     {
-      path: "/about",
-      name: "about",
+      path: '/about',
+      name: 'about',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/About.vue")
+      component: () => import('@/pages/About.vue'),
     },
     {
-      path: "/devices",
-      name: "devices",
+      path: '/devices',
+      name: 'devices',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/DeviceList.vue")
+      component: () => import('@/pages/DeviceList.vue'),
     },
     {
-      path: "/newGroup",
-      name: "newGroup",
+      path: '/newGroup',
+      name: 'newGroup',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/NewGroup.vue")
+      component: () => import('@/pages/NewGroup.vue'),
     },
     {
-      path: "/editGroup/:id",
-      name: "editGroup",
+      path: '/editGroup/:id',
+      name: 'editGroup',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/EditGroup.vue")
+      component: () => import('@/pages/EditGroup.vue'),
     },
     {
-      path: "/qr",
-      name: "qr",
+      path: '/qr',
+      name: 'qr',
       meta: {
         layout: Default,
         hasMenu: false,
         hasBackButton: true,
       },
-      component: () => import("@/pages/DeviceLinking.vue")
+      component: () => import('@/pages/DeviceLinking.vue'),
     },
     {
-      path: "/onboarding",
-      name: "onboarding",
+      path: '/onboarding',
+      name: 'onboarding',
       meta: {
         layout: Default,
         hasMenu: false,
         hasBackButton: true,
       },
-      component: () => import("@/pages/OnBoarding.vue")
+      component: () => import('@/pages/OnBoarding.vue'),
     },
     {
-      path: "/debug",
-      name: "debug",
+      path: '/debug',
+      name: 'debug',
       meta: {
         layout: Legacy,
       },
-      component: () => import("@/pages/Debug.vue")
+      component: () => import('@/pages/Debug.vue'),
     },
     {
-      path: '/a', redirect: () => {
-        return "/ws"
+      path: '/a',
+      redirect: () => {
+        return '/ws';
         // the function receives the target route as the argument
         // return redirect path/location here.
-      }
-    }
-  ]
+      },
+    },
+  ],
 });
 
 router.beforeEach((to, from, next) => {
   if (to.query.token) {
-    store.dispatch("setCaptchaToken",
-      to.query.token)
+    store.dispatch('setCaptchaToken', to.query.token);
   }
-  if (to.path === "/debug") {
+  if (to.path === '/debug') {
     return next();
   }
 
   if (store.state.registrationStatus === null) {
-    store.dispatch("getRegistrationStatus");
-    store.watch((state) => state.registrationStatus, function () {
-      proceed(to, next);
-    });
+    store.dispatch('getRegistrationStatus');
+    store.watch(
+      (state) => state.registrationStatus,
+      function () {
+        proceed(to, next);
+      },
+    );
   } else {
     proceed(to, next);
   }
 });
 
 function proceed(to, next) {
-  const registrationPages = ['/register', '/verify', '/password', '/pin', '/setUsername', '/qr', '/onboarding'];
+  const registrationPages = [
+    '/register',
+    '/verify',
+    '/password',
+    '/pin',
+    '/setUsername',
+    '/qr',
+    '/onboarding',
+  ];
   const registrationStatus = store.state.registrationStatus;
   //disable routes when registration is not finished yet
   if (registrationStatus === null && !registrationPages.includes(to.path)) {
     return next('/onboarding');
-  } else if (registrationStatus === "not_registered") {
+  } else if (registrationStatus === 'not_registered') {
     if (to.path === '/qr' || to.path === '/register' || to.path === '/onboarding') {
       let loader = document.getElementById('initial-loader');
-      if (typeof loader !== "undefined" && loader !== null) {
+      if (typeof loader !== 'undefined' && loader !== null) {
         loader.remove();
       }
       return next();
     }
     let loader = document.getElementById('initial-loader');
 
-    if (typeof loader !== "undefined" && loader !== null) {
+    if (typeof loader !== 'undefined' && loader !== null) {
       loader.remove();
     }
     return next('/onboarding');
-  }
-  else if ((registrationStatus === null || registrationStatus === "phoneNumber") && to.path !== '/register') {
+  } else if (
+    (registrationStatus === null || registrationStatus === 'phoneNumber') &&
+    to.path !== '/register'
+  ) {
     return next('/register');
-  } else if (registrationStatus === "verificationCode" && to.path !== '/verify') {
+  } else if (registrationStatus === 'verificationCode' && to.path !== '/verify') {
     return next('/verify');
-  } else if (registrationStatus === "pin" && to.path !== '/pin') {
+  } else if (registrationStatus === 'pin' && to.path !== '/pin') {
     return next('/pin');
-  } else if (registrationStatus === "password" && to.path !== '/password') {
+  } else if (registrationStatus === 'password' && to.path !== '/password') {
     return next('/password');
-  } else if (registrationStatus === "getUsername" && to.path !== '/setUsername') {
+  } else if (registrationStatus === 'getUsername' && to.path !== '/setUsername') {
     return next('/setUsername');
-  } else if (registrationStatus === "registered" && registrationPages.includes(to.path)) {
+  } else if (registrationStatus === 'registered' && registrationPages.includes(to.path)) {
     // We are registered. And are trying to access a registration page, redirect to home
     return next('/');
   } else {
     next();
     // The screen can be displayed ;)
     let loader = document.getElementById('initial-loader');
-    if (typeof loader !== "undefined" && loader !== null) {
+    if (typeof loader !== 'undefined' && loader !== null) {
       loader.remove();
     }
   }

--- a/axolotl-web/src/store/store.js
+++ b/axolotl-web/src/store/store.js
@@ -1,7 +1,7 @@
-import { createStore } from "vuex";
-import { router } from "../router/router";
-import { validateUUID } from "@/helpers/uuidCheck";
-import app from "../main";
+import { createStore } from 'vuex';
+import { router } from '../router/router';
+import { validateUUID } from '@/helpers/uuidCheck';
+import app from '../main';
 
 function socketSend(message) {
   app.config.globalProperties.$socket.send(JSON.stringify(message));
@@ -14,7 +14,7 @@ export default createStore({
     sessionNames: {},
     messageList: [],
     profile: null,
-    request: "",
+    request: '',
     contacts: [],
     contactsFiltered: [],
     contactsFilterActive: false,
@@ -47,7 +47,7 @@ export default createStore({
     lastChatlistUpdate: 0,
     socket: {
       isConnected: false,
-      message: "",
+      message: '',
       reconnectError: false,
       heartBeatInterval: 50000,
       heartBeatTimer: 0,
@@ -63,17 +63,17 @@ export default createStore({
 
   mutations: {
     SET_ERROR(state, error) {
-      if (error === "") {
+      if (error === '') {
         state.loginError = null;
         // state.rateLimitError = null;
         state.errorConnection = null;
-      } else if (error === "wrong password") {
+      } else if (error === 'wrong password') {
         state.loginError = error;
-      } else if (error.includes("Rate")) {
+      } else if (error.includes('Rate')) {
         state.rateLimitError = `${error}. Try again later!`;
-      } else if (error.includes("no such host") || error.includes("timeout")) {
+      } else if (error.includes('no such host') || error.includes('timeout')) {
         state.errorConnection = error;
-      } else if (error.includes("Your registration is faulty")) {
+      } else if (error.includes('Your registration is faulty')) {
         state.error = error;
       } else if (error.includes(400)) {
         //when pin is missing
@@ -81,8 +81,8 @@ export default createStore({
       } else if (error.includes(404)) {
         //when code was wrong
         if (state.verificationInProgress) state.verificationError = 404;
-      } else if (error.includes("RegistrationLockFailure")) {
-        state.verificationError = "RegistrationLockFailure";
+      } else if (error.includes('RegistrationLockFailure')) {
+        state.verificationError = 'RegistrationLockFailure';
       }
     },
     SET_CHATLIST(state, chatList) {
@@ -114,7 +114,7 @@ export default createStore({
     },
     UPDATE_CURRENT_CHAT(state, data) {
       state.currentChat = data.CurrentChat;
-      if (typeof state.messageList === "undefined") {
+      if (typeof state.messageList === 'undefined') {
         state.messageList = [];
       }
       const prepare = state.messageList.map((e) => e.ID);
@@ -148,34 +148,34 @@ export default createStore({
     SET_REQUEST(state, request) {
       const type = request.Type;
       state.request = request;
-      if (type === "getPhoneNumber") {
-        this.commit("SET_REGISTRATION_STATUS", "phoneNumber");
-      } else if (type === "getVerificationCode") {
-        this.commit("SET_REGISTRATION_STATUS", "verificationCode");
+      if (type === 'getPhoneNumber') {
+        this.commit('SET_REGISTRATION_STATUS', 'phoneNumber');
+      } else if (type === 'getVerificationCode') {
+        this.commit('SET_REGISTRATION_STATUS', 'verificationCode');
         state.verificationInProgress = true;
-        router.push("/verify");
-      } else if (type === "getPin") {
-        this.commit("SET_REGISTRATION_STATUS", "pin");
-        router.push("/pin");
+        router.push('/verify');
+      } else if (type === 'getPin') {
+        this.commit('SET_REGISTRATION_STATUS', 'pin');
+        router.push('/pin');
         state.requestPin = true;
-      } else if (type === "getCaptchaToken") {
-        window.location = "https://signalcaptchas.org/registration/generate.html";
-      } else if (type === "getEncryptionPw") {
-        this.commit("SET_REGISTRATION_STATUS", "password");
-        router.push("/password");
-      } else if (type === "registrationDone") {
-        this.commit("SET_REGISTRATION_STATUS", "registered");
-        router.push("/");
-      } else if (type === "requestEnterChat") {
+      } else if (type === 'getCaptchaToken') {
+        window.location = 'https://signalcaptchas.org/registration/generate.html';
+      } else if (type === 'getEncryptionPw') {
+        this.commit('SET_REGISTRATION_STATUS', 'password');
+        router.push('/password');
+      } else if (type === 'registrationDone') {
+        this.commit('SET_REGISTRATION_STATUS', 'registered');
+        router.push('/');
+      } else if (type === 'requestEnterChat') {
         router.push(`/chat/${request.Chat}`);
-        this.dispatch("getChatList");
-      } else if (type === "config") {
-        this.commit("SET_CONFIG", request);
-      } else if (type === "getUsername") {
-        this.commit("SET_REGISTRATION_STATUS", "getUsername");
-        router.push("/setUsername");
-      } else if (type === "Error") {
-        this.commit("SET_ERROR", request.Error);
+        this.dispatch('getChatList');
+      } else if (type === 'config') {
+        this.commit('SET_CONFIG', request);
+      } else if (type === 'getUsername') {
+        this.commit('SET_REGISTRATION_STATUS', 'getUsername');
+        router.push('/setUsername');
+      } else if (type === 'Error') {
+        this.commit('SET_ERROR', request.Error);
       }
     },
     SET_MESSAGELIST(state, messageList) {
@@ -272,7 +272,7 @@ export default createStore({
       state.currentGroup = null;
       state.currentContact = null;
       state.currentChat = null;
-      this.commit("CLEAR_MESSAGELIST");
+      this.commit('CLEAR_MESSAGELIST');
     },
     SET_CAPTCHA_TOKEN(state, token) {
       state.captchaToken = token;
@@ -284,13 +284,13 @@ export default createStore({
       app.config.globalProperties.$socket = event.currentTarget;
       state.socket.isConnected = true;
       state.socket.heartBeatTimer = setInterval(() => {
-        const message = "ping";
+        const message = 'ping';
         state.socket.isConnected &&
           app.config.globalProperties.$socket.send(
             JSON.stringify({
               request: message,
               code: 200,
-            })
+            }),
           );
         // this.dispatch("getChatList")
       }, state.socket.heartBeatInterval);
@@ -315,10 +315,10 @@ export default createStore({
       const messageData = JSON.parse(message.data);
 
       if (messageData.Error) {
-        this.commit("SET_ERROR", messageData.Error);
+        this.commit('SET_ERROR', messageData.Error);
       }
       switch (Object.keys(messageData)[0]) {
-        case "ChatList":{
+        case 'ChatList': {
           const chats = messageData.ChatList;
           if (messageData.LastMessages) {
             const lastMessages = {};
@@ -327,8 +327,8 @@ export default createStore({
             }
             chats.sort((a, b) => {
               if (
-                typeof lastMessages[a.ID] === "undefined" ||
-                typeof lastMessages[b.ID] === "undefined"
+                typeof lastMessages[a.ID] === 'undefined' ||
+                typeof lastMessages[b.ID] === 'undefined'
               ) {
                 return 0;
               }
@@ -340,110 +340,111 @@ export default createStore({
               }
               return 0;
             });
-            this.commit("SET_CHATLIST", chats);
-            this.commit("SET_LASTMESSAGES", lastMessages);
+            this.commit('SET_CHATLIST', chats);
+            this.commit('SET_LASTMESSAGES', lastMessages);
           } else {
-            this.commit("SET_CHATLIST", chats);
-            this.commit("SET_LASTMESSAGES", messageData.LastMessages);
+            this.commit('SET_CHATLIST', chats);
+            this.commit('SET_LASTMESSAGES', messageData.LastMessages);
           }
-          this.commit("SET_SESSIONNAMES", messageData.SessionNames);
+          this.commit('SET_SESSIONNAMES', messageData.SessionNames);
           break;
         }
-        case "MessageList":
-          this.commit("SET_MESSAGELIST", messageData.MessageList);
+        case 'MessageList':
+          this.commit('SET_MESSAGELIST', messageData.MessageList);
           break;
-        case "ContactList":
-          this.commit("SET_CONTACTS", messageData.ContactList);
+        case 'ContactList':
+          this.commit('SET_CONTACTS', messageData.ContactList);
           break;
-        case "MoreMessageList":
-          this.commit("SET_MORE_MESSAGELIST", messageData.MoreMessageList);
+        case 'MoreMessageList':
+          this.commit('SET_MORE_MESSAGELIST', messageData.MoreMessageList);
           break;
-        case "DeviceList":
-          this.commit("SET_DEVICELIST", messageData.DeviceList);
+        case 'DeviceList':
+          this.commit('SET_DEVICELIST', messageData.DeviceList);
           break;
-        case "MessageReceived":
-          this.commit("SET_MESSAGE_RECEIVED", messageData.MessageReceived);
+        case 'MessageReceived':
+          this.commit('SET_MESSAGE_RECEIVED', messageData.MessageReceived);
           break;
-        case "UpdateMessage":
-          this.commit("SET_MESSAGE_UPDATE", messageData.UpdateMessage);
+        case 'UpdateMessage':
+          this.commit('SET_MESSAGE_UPDATE', messageData.UpdateMessage);
           break;
-        case "Gui":
-          this.commit("SET_CONFIG_GUI", messageData.Gui);
+        case 'Gui':
+          this.commit('SET_CONFIG_GUI', messageData.Gui);
           break;
-        case "DarkMode":
-          this.commit("SET_CONFIG_DARK_MODE", messageData.DarkMode);
+        case 'DarkMode':
+          this.commit('SET_CONFIG_DARK_MODE', messageData.DarkMode);
           break;
-        case "CurrentChat":
-          this.commit("SET_CURRENT_CHAT", messageData.CurrentChat);
+        case 'CurrentChat':
+          this.commit('SET_CURRENT_CHAT', messageData.CurrentChat);
           break;
-        case "Type":
-          this.commit("SET_REQUEST", messageData);
+        case 'Type':
+          this.commit('SET_REQUEST', messageData);
           break;
-        case "FingerprintNumbers":
-          this.commit("SET_FINGERPRINT", messageData);
+        case 'FingerprintNumbers':
+          this.commit('SET_FINGERPRINT', messageData);
           break;
-        case "Error":
-          this.commit("SET_ERROR", messageData.Errorx);
+        case 'Error':
+          this.commit('SET_ERROR', messageData.Errorx);
           break;
-        case "OpenChat":
-          this.commit("OPEN_CHAT", messageData.OpenChat);
+        case 'OpenChat':
+          this.commit('OPEN_CHAT', messageData.OpenChat);
           break;
-        case "UpdateCurrentChat":
-          this.commit("UPDATE_CURRENT_CHAT", messageData.UpdateCurrentChat);
+        case 'UpdateCurrentChat':
+          this.commit('UPDATE_CURRENT_CHAT', messageData.UpdateCurrentChat);
           break;
-        case "ProfileMessage":
-          this.commit("SET_PROFILE", messageData.ProfileMessage);
+        case 'ProfileMessage':
+          this.commit('SET_PROFILE', messageData.ProfileMessage);
           break;
-        case "response_type":
-          if (messageData.response_type === "contact_list") {
-            this.commit("SET_CONTACTS", JSON.parse(messageData.data));
-          } else if (messageData.response_type === "chat_list") {
-            this.commit("SET_CHATLIST", JSON.parse(messageData.data));
-          } else if (messageData.response_type === "message_list") {
-            this.commit("SET_MESSAGELIST", JSON.parse(messageData.data));
-          } else if (messageData.response_type === "qr_code") {
-            this.commit("SET_DEVICE_LINK_CODE", messageData.data);
-          } else if (messageData.response_type === "phone_number") {
-            this.commit("SET_REGISTRATION_STATUS", "phone_number");
-            router.push("/register");
-          } else if (messageData.response_type === "registration_error") {
-            this.commit("SET_REGISTRATION_ERROR", messageData.data);
-          } else if (messageData.response_type === "pin") {
-            this.commit("SET_REGISTRATION_STATUS", "pin");
-            router.push("/pin");
-          } else if (messageData.response_type === "registration_start") {
-            this.commit("SET_REGISTRATION_STATUS", "not_registered");
-            router.push("/onboarding");
-          } else if (messageData.response_type === "profile") {
-            this.commit("SET_PROFILE", JSON.parse(messageData.data));
-          } else if (messageData.response_type === "current_chat") {
-            this.commit("SET_CURRENT_CHAT", JSON.parse(messageData.data));
-          } else if (messageData.response_type === "config") {
-            this.commit("SET_CONFIG", JSON.parse(messageData.data));
-          } else if (messageData.response_type === "message_received") {
+        case 'response_type':
+          if (messageData.response_type === 'contact_list') {
+            this.commit('SET_CONTACTS', JSON.parse(messageData.data));
+          } else if (messageData.response_type === 'chat_list') {
+            this.commit('SET_CHATLIST', JSON.parse(messageData.data));
+          } else if (messageData.response_type === 'message_list') {
+            this.commit('SET_MESSAGELIST', JSON.parse(messageData.data));
+          } else if (messageData.response_type === 'qr_code') {
+            this.commit('SET_DEVICE_LINK_CODE', messageData.data);
+          } else if (messageData.response_type === 'phone_number') {
+            this.commit('SET_REGISTRATION_STATUS', 'phone_number');
+            router.push('/register');
+          } else if (messageData.response_type === 'registration_error') {
+            this.commit('SET_REGISTRATION_ERROR', messageData.data);
+          } else if (messageData.response_type === 'pin') {
+            this.commit('SET_REGISTRATION_STATUS', 'pin');
+            router.push('/pin');
+          } else if (messageData.response_type === 'registration_start') {
+            this.commit('SET_REGISTRATION_STATUS', 'not_registered');
+            router.push('/onboarding');
+          } else if (messageData.response_type === 'profile') {
+            this.commit('SET_PROFILE', JSON.parse(messageData.data));
+          } else if (messageData.response_type === 'current_chat') {
+            this.commit('SET_CURRENT_CHAT', JSON.parse(messageData.data));
+          } else if (messageData.response_type === 'config') {
+            this.commit('SET_CONFIG', JSON.parse(messageData.data));
+          } else if (messageData.response_type === 'message_received') {
             const messageReceived = JSON.parse(messageData.data);
             if (
               state.currentChat &&
-              JSON.stringify(state.currentChat?.thread) === JSON.stringify(messageReceived.thread_id)
+              JSON.stringify(state.currentChat?.thread) ===
+                JSON.stringify(messageReceived.thread_id)
             ) {
-              this.commit("SET_MESSAGE_RECEIVED", messageReceived);
+              this.commit('SET_MESSAGE_RECEIVED', messageReceived);
             } else {
-              this.dispatch("getChatList");
+              this.dispatch('getChatList');
             }
-          } else if (messageData.response_type === "message_sent") {
+          } else if (messageData.response_type === 'message_sent') {
             const messageSent = JSON.parse(messageData.data);
-            this.commit("SET_MESSAGE_RECEIVED", messageSent.message);
-          } else if (messageData.response_type === "registration_done") {
-            this.commit("SET_REGISTRATION_STATUS", "registered");
-            router.push("/");
+            this.commit('SET_MESSAGE_RECEIVED', messageSent.message);
+          } else if (messageData.response_type === 'registration_done') {
+            this.commit('SET_REGISTRATION_STATUS', 'registered');
+            router.push('/');
           }
 
           break;
         default:
           // @ts-ignore
-          console.log("unkown message ", messageData, Object.keys(messageData)[0]);
+          console.log('unkown message ', messageData, Object.keys(messageData)[0]);
       }
-      this.commit("SET_SOCKET_MESSAGE_DATA", message.data);
+      this.commit('SET_SOCKET_MESSAGE_DATA', message.data);
     },
     SET_SOCKET_MESSAGE_DATA(state, data) {
       state.socket.message = data;
@@ -452,13 +453,13 @@ export default createStore({
       state.gui = gui;
     },
     SET_CONFIG_DARK_MODE(state, darkMode) {
-      if (window.getCookie("darkMode") !== String(darkMode)) {
+      if (window.getCookie('darkMode') !== String(darkMode)) {
         const d = new Date();
         d.setTime(d.getTime() + 300 * 24 * 60 * 60 * 1000);
         const expires = `expires=${d.toUTCString()}`;
         document.cookie = `darkMode=${darkMode};${expires};path=/`;
         state.darkMode = darkMode;
-        window.location.replace("/");
+        window.location.replace('/');
       }
     },
   },
@@ -467,7 +468,7 @@ export default createStore({
     addDevice(state, url) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "addDevice",
+          request: 'addDevice',
           data: url,
         };
         socketSend(message);
@@ -476,7 +477,7 @@ export default createStore({
     delDevice(state, id) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "delDevice",
+          request: 'delDevice',
           data: id,
         };
         socketSend(message);
@@ -485,16 +486,16 @@ export default createStore({
     getDevices() {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "getDevices",
+          request: 'getDevices',
         };
         socketSend(message);
       }
     },
     getChatList() {
       if (this.state.lastChatlistUpdate + 10000 < Date.now()) {
-        if (this.state.socket.isConnected && this.state.registrationStatus === "registered") {
+        if (this.state.socket.isConnected && this.state.registrationStatus === 'registered') {
           const message = {
-            request: "getChatList",
+            request: 'getChatList',
           };
           this.state.lastChatlistUpdate = Date.now();
           socketSend(message);
@@ -504,21 +505,21 @@ export default createStore({
     delChat(id) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "delChat",
+          request: 'delChat',
           data: this.state.currentChat.id,
         };
         socketSend(message);
       }
     },
     getMessageList(state, chatId) {
-      this.commit("CLEAR_MESSAGELIST");
+      this.commit('CLEAR_MESSAGELIST');
       if (this.state.socket.isConnected) {
         const data = {
           id: chatId,
         };
         if (chatId) {
           const message = {
-            request: "getMessageList",
+            request: 'getMessageList',
             data: JSON.stringify(data),
           };
           socketSend(message);
@@ -526,10 +527,10 @@ export default createStore({
       }
     },
     getProfile(state, id) {
-      this.commit("CLEAR_PROFILE");
+      this.commit('CLEAR_PROFILE');
       if (this.state.socket.isConnected) {
         const message = {
-          request: "getProfile",
+          request: 'getProfile',
           data: JSON.stringify({
             id,
           }),
@@ -540,7 +541,7 @@ export default createStore({
     createRecipient(state, recipient) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "createRecipient",
+          request: 'createRecipient',
           recipient,
         };
         socketSend(message);
@@ -549,7 +550,7 @@ export default createStore({
     createRecipientAndAddToGroup(state, data) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "createRecipientAndAddToGroup",
+          request: 'createRecipientAndAddToGroup',
           data: {
             recipient: data.id,
             group: data.group,
@@ -561,40 +562,40 @@ export default createStore({
     openChat({ dispatch }, chatId) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "openChat",
+          request: 'openChat',
           data: chatId,
         };
         socketSend(message);
-        dispatch("getMessageList", chatId);
+        dispatch('getMessageList', chatId);
       }
     },
     getMoreMessages() {
       if (
         this.state.socket.isConnected &&
-        typeof this.state.messageList !== "undefined" &&
+        typeof this.state.messageList !== 'undefined' &&
         this.state.messageList !== null &&
         this.state.messageList.length > 0 &&
         this.state.messageList[0].SentAt > 0
       ) {
         const firstMessage = this.state.messageList[0];
         const message = {
-          request: "getMoreMessages",
+          request: 'getMoreMessages',
           data: firstMessage.SentAt,
         };
         socketSend(message);
       }
     },
     clearMessageList() {
-      this.commit("CLEAR_MESSAGELIST");
+      this.commit('CLEAR_MESSAGELIST');
     },
     setCurrentChat(state, chat) {
-      this.commit("SET_CURRENT_CHAT", chat);
+      this.commit('SET_CURRENT_CHAT', chat);
     },
     leaveChat() {
-      this.commit("LEAVE_CHAT");
+      this.commit('LEAVE_CHAT');
       if (this.state.socket.isConnected) {
         const message = {
-          request: "leaveChat",
+          request: 'leaveChat',
         };
         socketSend(message);
       }
@@ -602,12 +603,12 @@ export default createStore({
     createChat(state, uuid) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "createChat",
+          request: 'createChat',
           data: uuid,
         };
         socketSend(message);
       }
-      this.commit("CREATE_CHAT", uuid);
+      this.commit('CREATE_CHAT', uuid);
     },
     sendMessage(state, messageContainer) {
       if (this.state.socket.isConnected) {
@@ -616,7 +617,7 @@ export default createStore({
           text: messageContainer.message,
         };
         const message = {
-          request: "sendMessage",
+          request: 'sendMessage',
           data: JSON.stringify(data),
         };
         socketSend(message);
@@ -630,7 +631,7 @@ export default createStore({
           archived: false,
         };
         const message = {
-          request: "changeNotificationsForThread",
+          request: 'changeNotificationsForThread',
           data: JSON.stringify(data),
         };
         socketSend(message);
@@ -639,7 +640,7 @@ export default createStore({
     resetEncryption() {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "resetEncryption",
+          request: 'resetEncryption',
           data: this.state.currentChat.id,
         };
         socketSend(message);
@@ -648,8 +649,8 @@ export default createStore({
     registerSecondaryDevice() {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "registerSecondaryDevice",
-          data: "",
+          request: 'registerSecondaryDevice',
+          data: '',
         };
         socketSend(message);
       }
@@ -657,7 +658,7 @@ export default createStore({
     verifyIdentity() {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "verifyIdentity",
+          request: 'verifyIdentity',
           data: this.state.currentChat.id,
         };
         socketSend(message);
@@ -667,8 +668,8 @@ export default createStore({
       if (this.state.socket.isConnected) {
         state.importingContacts = false;
         const message = {
-          request: "getContacts",
-          data: "",
+          request: 'getContacts',
+          data: '',
         };
         socketSend(message);
       }
@@ -677,20 +678,20 @@ export default createStore({
       if (this.state.socket.isConnected) {
         state.importingContacts = false;
         const message = {
-          request: "getContactSync",
-          data: "",
+          request: 'getContactSync',
+          data: '',
         };
         socketSend(message);
       }
     },
     addContact(state, contact) {
       state.rateLimitError = null;
-      if (this.state.socket.isConnected && contact.name !== "" && contact.phone !== "") {
+      if (this.state.socket.isConnected && contact.name !== '' && contact.phone !== '') {
         if (this.state.currentChat !== null && this.state.currentChat.Tel === contact.phone) {
-          this.commit("SET_CURRENT_CHAT_NAME", contact.name);
+          this.commit('SET_CURRENT_CHAT_NAME', contact.name);
         }
         const message = {
-          request: "addContact",
+          request: 'addContact',
           data: {
             name: contact.name,
             phone: contact.phone,
@@ -703,7 +704,7 @@ export default createStore({
     updateProfileName(state, data) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "updateProfileName",
+          request: 'updateProfileName',
           data: {
             name: data.name,
             id: data.id,
@@ -715,29 +716,29 @@ export default createStore({
     createChatForRecipient(state, data) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "openChat",
+          request: 'openChat',
           data: {
-            "Contact":data.id,
-          }
+            Contact: data.id,
+          },
         };
         socketSend(message);
       }
     },
     filterContacts(state, filter) {
-      this.commit("SET_CONTACTS_FILTER", filter);
+      this.commit('SET_CONTACTS_FILTER', filter);
     },
     filterContactsForGroup(state, filter) {
-      this.commit("SET_CONTACTS_FOR_GROUP_FILTER", filter);
+      this.commit('SET_CONTACTS_FOR_GROUP_FILTER', filter);
     },
     clearFilterContacts() {
-      this.commit("SET_CLEAR_CONTACTS_FILTER");
+      this.commit('SET_CLEAR_CONTACTS_FILTER');
     },
     uploadVcf(state, vcf) {
       state.rateLimitError = null;
       state.importingContacts = true;
       if (this.state.socket.isConnected) {
         const message = {
-          request: "uploadVcf",
+          request: 'uploadVcf',
           data: vcf,
         };
         socketSend(message);
@@ -750,7 +751,7 @@ export default createStore({
           recipient: attachment.to,
         };
         const message = {
-          request: "uploadAttachment",
+          request: 'uploadAttachment',
           data: JSON.stringify(data),
         };
         socketSend(message);
@@ -760,7 +761,7 @@ export default createStore({
       state.importingContacts = true;
       if (this.state.socket.isConnected) {
         const message = {
-          request: "refreshContacts",
+          request: 'refreshContacts',
           data: chUrl,
         };
         socketSend(message);
@@ -770,7 +771,7 @@ export default createStore({
       state.rateLimitError = null;
       if (this.state.socket.isConnected) {
         const message = {
-          request: "delContact",
+          request: 'delContact',
           data: id,
         };
         socketSend(message);
@@ -779,7 +780,7 @@ export default createStore({
     deleteSelfDestructingMessage(state, m) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "delMessage",
+          request: 'delMessage',
           data: m.id,
         };
         socketSend(message);
@@ -789,10 +790,10 @@ export default createStore({
       state.rateLimitError = null;
       if (this.state.socket.isConnected) {
         if (this.state.currentChat !== null && this.state.currentChat.Tel === data.contact.Tel) {
-          this.commit("SET_CURRENT_CHAT_NAME", data.contact.Name);
+          this.commit('SET_CURRENT_CHAT_NAME', data.contact.Name);
         }
         const message = {
-          request: "editContact",
+          request: 'editContact',
           data: {
             phone: data.contact.Tel,
             name: data.contact.Name,
@@ -808,7 +809,7 @@ export default createStore({
       this.state.verificationError = null;
       if (this.state.socket.isConnected) {
         const message = {
-          request: "requestCode",
+          request: 'requestCode',
           data: tel,
         };
         socketSend(message);
@@ -817,19 +818,19 @@ export default createStore({
     sendCode(state, code) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "sendCode",
+          request: 'sendCode',
           data: code,
         };
         socketSend(message);
       } else {
-        console.error("socket not connected");
+        console.error('socket not connected');
         // reconnect socket
       }
     },
     setUsername(state, username) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "sendUsername",
+          request: 'sendUsername',
           data: username,
         };
         socketSend(message);
@@ -838,7 +839,7 @@ export default createStore({
     sendPin(state, pin) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "sendPin",
+          request: 'sendPin',
           data: pin,
         };
         socketSend(message);
@@ -847,7 +848,7 @@ export default createStore({
     sendPassword(state, password) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "sendPassword",
+          request: 'sendPassword',
           data: password,
         };
         socketSend(message);
@@ -856,20 +857,20 @@ export default createStore({
     setPassword(state, password) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "setPassword",
+          request: 'setPassword',
           data: {
             pw: password.pw,
             currentPw: password.cPw,
           },
         };
         socketSend(message);
-        router.push("/chatList");
+        router.push('/chatList');
       }
     },
     getRegistrationStatus() {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "getRegistrationStatus",
+          request: 'getRegistrationStatus',
         };
         socketSend(message);
       }
@@ -877,7 +878,7 @@ export default createStore({
     unregister() {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "unregister",
+          request: 'unregister',
         };
         socketSend(message);
       }
@@ -885,7 +886,7 @@ export default createStore({
     getConfig() {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "getConfig",
+          request: 'getConfig',
         };
         socketSend(message);
       }
@@ -893,7 +894,7 @@ export default createStore({
     createNewGroup(state, data) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "createGroup",
+          request: 'createGroup',
           data: {
             name: data.name,
             members: data.members,
@@ -905,7 +906,7 @@ export default createStore({
     updateGroup(state, data) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "updateGroup",
+          request: 'updateGroup',
           data: {
             name: data.name,
             id: data.id,
@@ -918,7 +919,7 @@ export default createStore({
     joinGroup(state, data) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "joinGroup",
+          request: 'joinGroup',
           data,
         };
         socketSend(message);
@@ -928,11 +929,11 @@ export default createStore({
       if (this.state.socket.isConnected) {
         const mapped_data = {
           mimetype: data.type,
-          path: data.path.replace("file://", ""),
+          path: data.path.replace('file://', ''),
           recipient: data.to,
         };
         const message = {
-          request: "sendAttachment",
+          request: 'sendAttachment',
           data: JSON.stringify(mapped_data),
         };
         socketSend(message);
@@ -941,7 +942,7 @@ export default createStore({
     sendVoiceNote(state, voiceNote) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "sendVoiceNote",
+          request: 'sendVoiceNote',
           data: {
             attachment: voiceNote.note,
             to: voiceNote.to,
@@ -953,7 +954,7 @@ export default createStore({
     setDarkMode(state, darkMode) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "setDarkMode",
+          request: 'setDarkMode',
           data: darkMode,
         };
         socketSend(message);
@@ -963,24 +964,24 @@ export default createStore({
     sendCaptchaToken() {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "sendCaptchaToken",
+          request: 'sendCaptchaToken',
           data: this.state.captchaToken,
         };
         socketSend(message);
-        this.commit("SET_CAPTCHA_TOKEN_SENT");
+        this.commit('SET_CAPTCHA_TOKEN_SENT');
       }
     },
     setLogLevel(state, level) {
       if (this.state.socket.isConnected) {
         const message = {
-          request: "setLogLevel",
+          request: 'setLogLevel',
           level,
         };
         socketSend(message);
       }
     },
     setCaptchaToken(state, token) {
-      this.commit("SET_CAPTCHA_TOKEN", token);
+      this.commit('SET_CAPTCHA_TOKEN', token);
     },
   },
 });


### PR DESCRIPTION
All the dependencies were in place, but prettier wasnt added to eslint, and thus not used.

The one manual change in this PR is this line:

axolotl-web/.eslintrc.cjs

```
  extends: ['plugin:vue/vue3-recommended', 'plugin:prettier/recommended'],
```

For all available options, see here:
https://prettier.io/docs/en/options.html

The configuration of prettier can be done either in a separate file, or as I did on this branch, inside package.json.

As we already run eslint with the --fix option, this effectively turns on the autoformatting options when running lint.